### PR TITLE
Clear effect layers each frame and normalize WASD input

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,9 +48,10 @@ const spells = new Spellbook(inventory, party);
 
 const combat = new CombatSystem(party, inventory, spells, gameC, ctx, fx, gridLayer);
 
-const keys={};
-addEventListener('keydown', e=>keys[e.key]=true);
-addEventListener('keyup', e=>keys[e.key]=false);
+const keys = {};
+function normalizeKey(k){ return k.length === 1 ? k.toLowerCase() : k; }
+addEventListener('keydown', e=>{ keys[normalizeKey(e.key)] = true; });
+addEventListener('keyup', e=>{ keys[normalizeKey(e.key)] = false; });
 
 document.getElementById('btnTalk').onclick = async () => {
   const npc = { name:'Britain Guard', profession:'Guard', town:'Britain', personality:'formal, dutiful' };
@@ -128,6 +129,11 @@ function updateTerrainPill() {
 let last = performance.now();
 function loop(){
   const now = performance.now(), dt = (now-last)/1000; last = now;
+  // Clear canvases that accumulate drawing each frame.
+  // Without clearing, the fx layer's bloom/lights compound and the screen
+  // quickly washes out or turns black when bloom is toggled.
+  ctx.clearRect(0,0,innerWidth,innerHeight);
+  fx.clearRect(0,0,innerWidth,innerHeight);
   back.clearRect(0,0,innerWidth,innerHeight); sky.clearRect(0,0,innerWidth,innerHeight);
   drawSky(sky, back, dt, innerWidth, innerHeight);
 


### PR DESCRIPTION
## Summary
- Clear game and effect canvases on each frame to stop bloom accumulation
- Normalize key handling so WASD input works regardless of case

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c167fb47588324a05d47e561e979c3