### PR TITLE
Clean up inventory overweight markup

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -41,8 +41,8 @@ export function updateInventoryUI(inv, party){
     let equipStatus = '';
     let packStatus = '';
     if (party && party.members) {
-      equipStatus = party.members.map(m => `${m.name}: ${m.equippedWeight ? m.equippedWeight() : 0}/${m.STR}${m.isOverweight && m.isOverweight() && m.equippedWeight && m.equippedWeight() > m.STR ? ' <span style=\"color:#ff6b6b\">[Over]</span>' : ''}`).join(', ');
-      packStatus = party.members.map(m => `${m.name}: ${m.backpackWeight ? m.backpackWeight() : 0}/${m.packLimit ? m.packLimit() : 0}${m.isOverweight && m.isOverweight() && m.backpackWeight && m.backpackWeight() > m.packLimit() ? ' <span style=\"color:#ff6b6b\">[Over]</span>' : ''}`).join(', ');
+      equipStatus = party.members.map(m => `${m.name}: ${m.equippedWeight ? m.equippedWeight() : 0}/${m.STR}${m.isOverweight && m.isOverweight() && m.equippedWeight && m.equippedWeight() > m.STR ? ' <span style="color:#ff6b6b">[Over]</span>' : ''}`).join(', ');
+      packStatus = party.members.map(m => `${m.name}: ${m.backpackWeight ? m.backpackWeight() : 0}/${m.packLimit ? m.packLimit() : 0}${m.isOverweight && m.isOverweight() && m.backpackWeight && m.backpackWeight() > m.packLimit() ? ' <span style="color:#ff6b6b">[Over]</span>' : ''}`).join(', ');
     }
     document.getElementById('equipRule').innerHTML = equipStatus || 'equip ≤ STR';
     document.getElementById('packRule').innerHTML = packStatus || 'pack ≤ STR×2';


### PR DESCRIPTION
## Summary
- simplify overweight indicators in inventory UI by removing unnecessary escape sequences

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c1696e01c083249d5c5b27e93719d3