### PR TITLE
Reduce movement speed when overweight

### DIFF
--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ function loop(){
     if(mvx||mvy){
       const len=Math.hypot(mvx,mvy); mvx/=len; mvy/=len;
       const terr = TERRAIN.at(Math.floor(party.leader.x/TILE), Math.floor(party.leader.y/TILE));
-      let s = party.leader.baseSpeed;
+      let s = party.leader.speed();
       if(terr.key==='SWAMP'){ s*=0.7; if(Math.random()<0.02){ party.leader.applyPoison(1); } }
       if(terr.key==='FOREST'){ s*=0.86; }
       if(terr.key==='ROAD'){ s*=1.22; }

--- a/party.js
+++ b/party.js
@@ -73,6 +73,9 @@ export class Character {
   isOverweight() {
     return this.equippedWeight() > this.STR || this.backpackWeight() > this.packLimit();
   }
+  speed() {
+    return this.baseSpeed * (this.isOverweight() ? 0.6 : 1);
+  }
   applyPoison(turns){ this.poisoned=true; this.poisonTurns=Math.min(5, (this.poisonTurns||0)+turns); }
   tick(dt){
     if(this.poisoned && Math.random()<0.015){ this.hp = Math.max(0, this.hp-1); }

--- a/tests/character.test.js
+++ b/tests/character.test.js
@@ -40,3 +40,14 @@ describe('Equipment and pack weight limits', () => {
     expect(c.isOverweight()).toBe(true);
   });
 });
+
+describe('Movement speed when overweight', () => {
+  it('reduces speed when character is overweight', () => {
+    const c = new Character({ name: 'A', cls: CharacterClass.Fighter, STR: 5, DEX: 5, INT: 5 });
+    c.baseSpeed = 100;
+    expect(c.speed()).toBe(100);
+    c.equipment.torso = demoItem({ weight: 6 });
+    expect(c.isOverweight()).toBe(true);
+    expect(c.speed()).toBeCloseTo(60);
+  });
+});


### PR DESCRIPTION
## Summary
- add `speed()` helper to characters that returns base speed with overweight penalty
- use character speed in world movement logic
- add unit test covering overweight movement penalty

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c175b301a48324b753403336f2ff33