### PR TITLE
Persist camera offset during movement

### DIFF
--- a/main.js
+++ b/main.js
@@ -113,7 +113,6 @@ function centerCameraOnLeader(){
   camY = party.leader.y - innerHeight/2;
   console.info('Boot: party size=', party.size, 'leader=', party.leader.name, 'coords=', Math.round(party.leader.x), Math.round(party.leader.y));
 }
-centerCameraOnLeader();
 onResize();
 
 // Ensure party members have sensible world coordinates (place near screen center)
@@ -178,17 +177,13 @@ function loop(){
     if(terr.key==='WATER'){ s*=0.5; }
     if(terr.key==='SAND'){ s*=0.92; }
     party.move(mvx*s*dt, mvy*s*dt);
+    camX += mvx * s * dt;
+    camY += mvy * s * dt;
     updateTerrainPill();
   }
   if(combat.active){
     combat.update(dt);
   }
-
-  // Always center camera on leader after movement
-  camX = party.leader.x - innerWidth/2;
-  camY = party.leader.y - innerHeight/2;
-  // Optionally, call centerCameraOnLeader() if needed
-
   const gameW = innerWidth, gameH = innerHeight;
   const view = {camX, camY, W:gameW, H:gameH};
   // Debug: draw a small red crosshair at screen center to ensure game canvas is visible


### PR DESCRIPTION
## Summary
- Move camera incrementally with party movement instead of resetting to the leader every frame
- Pass updated camera position to world and party rendering via the `view` object
- Only recenter camera on resize to avoid constant resets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5ec5a048324a3848c649ec24d32