### PR TITLE
Prevent page scrolling on arrow keys

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,8 +50,9 @@ const combat = new CombatSystem(party, inventory, spells, gameC, ctx, fx, gridLa
 
 // Keyboard input: bind to window
 export const keys = Object.create(null);
-window.addEventListener('keydown', e => { keys[e.key] = true; });
-window.addEventListener('keyup',   e => { keys[e.key] = false; });
+// Prevent default browser behavior (e.g., page scrolling) on key events
+window.addEventListener('keydown', e => { keys[e.key] = true; e.preventDefault(); });
+window.addEventListener('keyup',   e => { keys[e.key] = false; e.preventDefault(); });
 window.addEventListener('blur',    () => { for (const k in keys) keys[k] = false; });
 
 // Focus logic


### PR DESCRIPTION
## Summary
- prevent default browser behavior on keydown and keyup events to stop page scrolling

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5f72c748324a7ef1b29b9fd7bf1