### PR TITLE
Keep game loop running if a frame throws

### DIFF
--- a/main.js
+++ b/main.js
@@ -194,14 +194,16 @@ function updateTerrainPill() {
 
 let last = performance.now();
 function loop(){
-  const now = performance.now(), dt = (now-last)/1000; last = now;
-  // Clear canvases that accumulate drawing each frame.
-  // Without clearing, the fx layer's bloom/lights compound and the screen
-  // quickly washes out or turns black when bloom is toggled.
-  ctx.clearRect(0,0,innerWidth,innerHeight);
-  fx.clearRect(0,0,innerWidth,innerHeight);
-  back.clearRect(0,0,innerWidth,innerHeight); sky.clearRect(0,0,innerWidth,innerHeight);
-  drawSky(sky, back, dt, innerWidth, innerHeight);
+  requestAnimationFrame(loop);
+  try {
+    const now = performance.now(), dt = (now-last)/1000; last = now;
+    // Clear canvases that accumulate drawing each frame.
+    // Without clearing, the fx layer's bloom/lights compound and the screen
+    // quickly washes out or turns black when bloom is toggled.
+    ctx.clearRect(0,0,innerWidth,innerHeight);
+    fx.clearRect(0,0,innerWidth,innerHeight);
+    back.clearRect(0,0,innerWidth,innerHeight); sky.clearRect(0,0,innerWidth,innerHeight);
+    drawSky(sky, back, dt, innerWidth, innerHeight);
 
   let mvx=0,mvy=0;
   if(keys['ArrowLeft']||keys['a']) mvx-=1;
@@ -256,8 +258,9 @@ function loop(){
   // no debug overlay in production
 
   combat.drawLighting(fx, view, party.leader);
-  if(document.getElementById('bloom').checked) combat.compositeBloom(gameC, fxC, innerWidth, innerHeight);
-
-  requestAnimationFrame(loop);
+    if(document.getElementById('bloom').checked) combat.compositeBloom(gameC, fxC, innerWidth, innerHeight);
+  } catch (err) {
+    console.error('loop iteration failed', err);
+  }
 }
 requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- Avoid frozen camera/party by always scheduling the next frame at the top of the render loop
- Wrap render loop in a try/catch so a thrown error doesn't halt updates

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c275d797808324b71c9155dfc7ec4e