### PR TITLE
Normalize legacy key names for movement

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,14 +52,29 @@ const combat = new CombatSystem(party, inventory, spells, gameC, ctx, fx, gridLa
 
 // Keyboard input: bind to window
 export const keys = Object.create(null);
+
+function normalizeKey(k) {
+  const map = {
+    Left: 'ArrowLeft',
+    Right: 'ArrowRight',
+    Up: 'ArrowUp',
+    Down: 'ArrowDown',
+    ' ': ' ',
+    Spacebar: ' ',
+    Space: ' '
+  };
+  if (k in map) return map[k];
+  return k.length === 1 ? k.toLowerCase() : k;
+}
+
 // Prevent default browser behavior (e.g., page scrolling) on key events
 window.addEventListener('keydown', e => {
-  const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+  const key = normalizeKey(e.key);
   keys[key] = true;
   e.preventDefault();
 });
 window.addEventListener('keyup', e => {
-  const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+  const key = normalizeKey(e.key);
   keys[key] = false;
   e.preventDefault();
 });


### PR DESCRIPTION
## Summary
- normalize keyboard event keys for cross-browser compatibility

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c27ec7f8448324a2278cf7c3140214