### PR TITLE
Focus canvas on load for immediate keyboard input

### DIFF
--- a/main.js
+++ b/main.js
@@ -116,7 +116,7 @@ const gameCanvas = document.getElementById('game');
 const focusOverlay = document.getElementById('focusOverlay');
 function showFocusOverlay() {
   focusOverlay.style.display = 'block';
-  focusOverlay.textContent = 'Click to focus · Use WASD/Arrows to move';
+  focusOverlay.textContent = 'Click to refocus · Use WASD/Arrows to move';
 }
 function hideFocusOverlay() {
   focusOverlay.style.display = 'none';
@@ -132,7 +132,10 @@ gameCanvas.addEventListener('mousedown', () => { gameCanvas.focus(); });
 gameCanvas.addEventListener('touchstart', () => { gameCanvas.focus(); });
 window.addEventListener('focus', checkFocus);
 window.addEventListener('blur', checkFocus);
-document.addEventListener('DOMContentLoaded', checkFocus);
+document.addEventListener('DOMContentLoaded', () => {
+  gameCanvas.focus();
+  checkFocus();
+});
 setTimeout(checkFocus, 500);
 
 document.getElementById('btnTalk').onclick = async () => {


### PR DESCRIPTION
## Summary
- Focus the game canvas on DOMContentLoaded so movement keys work without an initial click
- Clarify focus overlay text to indicate clicking only when refocusing is needed

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c280cf970c83249eb5e961f5f5fa2a