### PR TITLE
Prevent casting during enemy turn

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,6 +152,7 @@ document.getElementById('btnTalk').onclick = async () => {
 };
 document.getElementById('btnCombat').onclick = ()=>combat.startSkirmish();
 document.getElementById('btnCast').onclick = ()=>{
+  if(combat.active && combat.turn !== 'player') return showToast('Wait for your turn');
   const caster = party.members[0];
   if(!spells.canCast('fire_dart', caster)) return showToast('Need Sulfur Ash + Black Pearl and MP');
   castFireDart(caster, combat, ctx, fx, inventory, spells);


### PR DESCRIPTION
## Summary
- Block casting Fire Dart while combat is active and it's not the player's turn

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c283f8b4248324ae434cab66daf0e4