### PR TITLE
Allow browser refresh keys

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,15 +68,20 @@ function normalizeKey(k) {
 }
 
 // Prevent default browser behavior (e.g., page scrolling) on key events
+function isRefreshCombo(e) {
+  return e.key.startsWith('F') ||
+    (e.key.toLowerCase() === 'r' && (e.ctrlKey || e.metaKey));
+}
+
 window.addEventListener('keydown', e => {
   const key = normalizeKey(e.key);
   keys[key] = true;
-  e.preventDefault();
+  if (!isRefreshCombo(e)) e.preventDefault();
 });
 window.addEventListener('keyup', e => {
   const key = normalizeKey(e.key);
   keys[key] = false;
-  e.preventDefault();
+  if (!isRefreshCombo(e)) e.preventDefault();
 });
 window.addEventListener('blur', () => { for (const k in keys) keys[k] = false; });
 


### PR DESCRIPTION
## Summary
- allow browser refresh keys by skipping default prevention for F-keys and Ctrl/Cmd+R

## Testing
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c2859631f48324a286e442758e1edc