### PR TITLE
Handle missing selected text

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ import { Inventory } from './inventory.js';
 import { Spellbook, castFireDart } from './spells.js';
 import { CombatSystem } from './combat.js';
 import { pushBubble, pushActions, showToast, updatePartyUI, updateInventoryUI, gridLayer } from './ui.js';
+import { getSelectedText } from './selection.js';
 import { talkToNPC } from './ai.js';
 
 const dpr = Math.min(window.devicePixelRatio||1, 2);
@@ -149,7 +150,8 @@ document.getElementById('btnTalk').onclick = async () => {
   const questState = party.activeQuests;
   const playerState = { name: party.members[0].name, karma: party.karma, items: inventory.summary() };
   pushBubble('Britain Guard', 'Halt! State thy business in Britain.');
-  const { text } = await talkToNPC(npc, worldState, playerState, questState, 'We seek news and work.');
+  const playerInput = getSelectedText(window.getSelection()) || 'We seek news and work.';
+  const { text } = await talkToNPC(npc, worldState, playerState, questState, playerInput);
   pushBubble('Britain Guard', text);
   pushActions([
     {label:'Accept Quest', fn:()=>{ pushBubble('System','Quest Accepted: Clear bandits by the northern bridge.'); party.acceptQuest({id:'bandits_bridge', name:'Clear the Bandits'}); updatePartyUI(party);}}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/character.test.js",{"duration":9.444438999999988,"failed":false}],[":tests/spellbook.test.js",{"duration":3.407987999999932,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/character.test.js",{"duration":14.479211999999961,"failed":false}],[":tests/spellbook.test.js",{"duration":6.015587000000096,"failed":false}],[":tests/selection.test.js",{"duration":11.932660000000055,"failed":false}]]}

--- a/selection.js
+++ b/selection.js
@@ -1,0 +1,10 @@
+export function getSelectedText(selection) {
+  if (!selection) return '';
+  if (typeof selection.selectedText !== 'undefined') {
+    return selection.selectedText;
+  }
+  if (typeof selection.toString === 'function') {
+    return selection.toString();
+  }
+  return '';
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -11,7 +11,8 @@ const ASSETS = [
   '/spells.js',
   '/combat.js',
   '/ui.js',
-  '/ai.js'
+  '/ai.js',
+  '/selection.js'
 ];
 
 self.addEventListener('install', event => {

--- a/tests/selection.test.js
+++ b/tests/selection.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getSelectedText } from '../selection.js';
+
+describe('getSelectedText', () => {
+  it('returns selectedText when available', () => {
+    const sel = { selectedText: 'Hello' };
+    expect(getSelectedText(sel)).toBe('Hello');
+  });
+
+  it('falls back to toString if selectedText missing', () => {
+    const sel = { toString: () => 'World' };
+    expect(getSelectedText(sel)).toBe('World');
+  });
+
+  it('returns empty string for null or undefined', () => {
+    expect(getSelectedText(null)).toBe('');
+    expect(getSelectedText(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Safely derive selected text from selection objects with new helper.
- Use the helper in NPC dialog to avoid undefined `selectedText` errors.
- Cache new helper module in the service worker and cover behavior with tests.

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c297ea093483248b44fd938351e9bf