### PR TITLE
Handle cache failures in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,23 +1,30 @@
 const CACHE_VERSION = 'v1';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/style.css',
-  '/main.js',
-  '/world.js',
-  '/party.js',
-  '/inventory.js',
-  '/spells.js',
-  '/combat.js',
-  '/ui.js',
-  '/ai.js',
-  '/selection.js'
+  'index.html',
+  'style.css',
+  'main.js',
+  'world.js',
+  'party.js',
+  'inventory.js',
+  'spells.js',
+  'combat.js',
+  'ui.js',
+  'ai.js',
+  'selection.js'
 ];
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(STATIC_CACHE).then(cache => cache.addAll(ASSETS))
+    caches.open(STATIC_CACHE).then(cache =>
+      Promise.all(
+        ASSETS.map(url =>
+          cache.add(url).catch(err =>
+            console.warn('Failed to cache', url, err)
+          )
+        )
+      )
+    )
   );
 });
 


### PR DESCRIPTION
## Summary
- avoid cache.addAll aborting on bad URLs by caching assets individually with error handling
- use relative asset paths so service worker installs offline cache reliably

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c29a85e4a083249daf75185abdbe08