### PR TITLE
Remove bloom effect

### DIFF
--- a/combat.js
+++ b/combat.js
@@ -57,11 +57,6 @@ export class CombatSystem {
     }
     fx.globalCompositeOperation='source-over';
   }
-  compositeBloom(gameC, fxC, W, H){
-    this.fx.save(); this.fx.globalCompositeOperation='lighter'; this.fx.filter='blur(6px)';
-    this.fx.drawImage(gameC,0,0,W,H); this.fx.drawImage(fxC,0,0,W,H);
-    this.fx.filter='none'; this.fx.restore();
-  }
 }
 
 function drawGrid(svg, show){

--- a/index.html
+++ b/index.html
@@ -24,13 +24,10 @@
           <button class="btn" id="btnCast">Cast: Fire Dart</button>
           <button class="btn" id="btnEndTurn" disabled>End Turn</button>
         </div>
-        <div class="right">
-          <div class="pill" id="terrainPill">Terrain: Road</div>
-          <label class="pill" style="display:flex;gap:8px;align-items:center;padding-right:12px">
-            <input type="checkbox" id="bloom" checked style="accent-color:#52c8ff"> Bloom
-          </label>
+          <div class="right">
+            <div class="pill" id="terrainPill">Terrain: Road</div>
+          </div>
         </div>
-      </div>
 
       <div class="panel">
         <div class="card glow" id="partyCard">

--- a/main.js
+++ b/main.js
@@ -225,8 +225,8 @@ function loop(){
   try {
     const now = performance.now(), dt = (now-last)/1000; last = now;
     // Clear canvases that accumulate drawing each frame.
-    // Without clearing, the fx layer's bloom/lights compound and the screen
-    // quickly washes out or turns black when bloom is toggled.
+    // Without clearing, the fx layer's lights compound and the screen
+    // quickly washes out.
     ctx.clearRect(0,0,innerWidth,innerHeight);
     fx.clearRect(0,0,innerWidth,innerHeight);
     back.clearRect(0,0,innerWidth,innerHeight); sky.clearRect(0,0,innerWidth,innerHeight);
@@ -284,9 +284,8 @@ function loop(){
 
   // no debug overlay in production
 
-  combat.drawLighting(fx, view, party.leader);
-    if(document.getElementById('bloom').checked) combat.compositeBloom(gameC, fxC, innerWidth, innerHeight);
-  } catch (err) {
+    combat.drawLighting(fx, view, party.leader);
+    } catch (err) {
     console.error('loop iteration failed', err);
   }
 }


### PR DESCRIPTION
## Summary
- remove bloom toggle from topbar UI
- drop bloom compositing and related cleanup from main render loop
- delete compositeBloom helper from combat system

## Testing
- `npm ci`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c2b91735448324920a30aab339f8ca