### PR TITLE
feat: add basic Three.js overworld modules

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -1,0 +1,46 @@
+import { moveHeroToTile, getHeroWorldPos } from './world3d.js';
+
+const keys = Object.create(null);
+let bounds = { width:32, depth:32 };
+let cameraRig = null;
+let moveCooldown = 0;
+
+export function initControls(opts={}){
+  bounds.width = opts.width || bounds.width;
+  bounds.depth = opts.depth || bounds.depth;
+  cameraRig = opts.cameraRig || null;
+
+  window.addEventListener('keydown', e=>{ keys[e.key] = true; });
+  window.addEventListener('keyup', e=>{ keys[e.key] = false; });
+}
+
+function clamp(v,min,max){ return Math.max(min, Math.min(max, v)); }
+
+export function updateControls(dt){
+  moveCooldown -= dt;
+  const pos = getHeroWorldPos();
+  let tx = Math.floor(pos.x);
+  let tz = Math.floor(pos.z);
+  let moved = false;
+
+  if(moveCooldown<=0){
+    if(keys['w'] || keys['ArrowUp']){ tz -=1; moved=true; }
+    else if(keys['s'] || keys['ArrowDown']){ tz +=1; moved=true; }
+    else if(keys['a'] || keys['ArrowLeft']){ tx -=1; moved=true; }
+    else if(keys['d'] || keys['ArrowRight']){ tx +=1; moved=true; }
+    if(moved){
+      tx = clamp(tx,0,bounds.width-1);
+      tz = clamp(tz,0,bounds.depth-1);
+      moveHeroToTile(tx, tz);
+      moveCooldown = 0.2; // seconds between steps
+    }
+  }
+
+  if(keys['Shift']){
+    const rotSpeed = 1.5 * dt;
+    if(keys['ArrowLeft']) cameraRig.rotation.y += rotSpeed;
+    if(keys['ArrowRight']) cameraRig.rotation.y -= rotSpeed;
+    if(keys['ArrowUp']) cameraRig.rotation.x += rotSpeed;
+    if(keys['ArrowDown']) cameraRig.rotation.x -= rotSpeed;
+  }
+}

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,47 @@
+import * as THREE from 'three';
+
+let renderer, scene, camera, cameraRig;
+
+export function initRenderer(container=document.body){
+  renderer = new THREE.WebGLRenderer({ antialias:true });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.setPixelRatio(window.devicePixelRatio || 1);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  container.appendChild(renderer.domElement);
+
+  scene = new THREE.Scene();
+
+  cameraRig = new THREE.Group();
+  camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+  camera.position.set(0,5,5);
+  camera.lookAt(0,0,0);
+  cameraRig.add(camera);
+  scene.add(cameraRig);
+
+  const hemi = new THREE.HemisphereLight(0xffffff, 0x444444, 0.6);
+  scene.add(hemi);
+  const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+  dir.position.set(5,10,2);
+  dir.castShadow = true;
+  dir.shadow.mapSize.set(1024,1024);
+  scene.add(dir);
+
+  window.addEventListener('resize', onWindowResize);
+  return { renderer, scene, camera, cameraRig };
+}
+
+function onWindowResize(){
+  if(!renderer || !camera) return;
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+}
+
+export function render(){
+  if(renderer && scene && camera){
+    renderer.render(scene, camera);
+  }
+}

--- a/world3d.js
+++ b/world3d.js
@@ -1,0 +1,99 @@
+import * as THREE from 'three';
+
+export const TILE_TYPES = {
+  grass: 0x3a5d2a,
+  road: 0x8b6e4a,
+  water: 0x3a6ea5,
+  town: 0xbfb398
+};
+
+let width = 0, depth = 0;
+let tileMesh, hero, worldGroup;
+let cameraRig = null;
+
+const matrix = new THREE.Matrix4();
+const color = new THREE.Color();
+const tileColors = [];
+const raycaster = new THREE.Raycaster();
+
+export function initWorld3D(w = 32, d = 32) {
+  width = w; depth = d;
+  worldGroup = new THREE.Group();
+
+  const geom = new THREE.PlaneGeometry(1,1);
+  geom.rotateX(-Math.PI/2);
+  const mat = new THREE.MeshStandardMaterial({ vertexColors: true });
+  tileMesh = new THREE.InstancedMesh(geom, mat, w * d);
+
+  let i = 0;
+  for (let z = 0; z < d; z++) {
+    for (let x = 0; x < w; x++) {
+      matrix.setPosition(x + 0.5, 0, z + 0.5);
+      tileMesh.setMatrixAt(i, matrix);
+      const col = TILE_TYPES.grass;
+      tileMesh.setColorAt(i, color.setHex(col));
+      tileColors[i] = col;
+      i++;
+    }
+  }
+  tileMesh.instanceMatrix.needsUpdate = true;
+  tileMesh.instanceColor.needsUpdate = true;
+  worldGroup.add(tileMesh);
+
+  const heroGeo = new THREE.SphereGeometry(0.3, 16, 16);
+  const heroMat = new THREE.MeshStandardMaterial({ color: 0xffee00 });
+  hero = new THREE.Mesh(heroGeo, heroMat);
+  hero.castShadow = true;
+  hero.position.set(0.5, 0.3, 0.5);
+  worldGroup.add(hero);
+
+  return { world: worldGroup, tiles: tileMesh, hero };
+}
+
+export function attachCameraRig(rig){
+  cameraRig = rig;
+  if(cameraRig){
+    cameraRig.position.set(0,0,0);
+  }
+}
+
+export function updateWorld3D(dt){
+  if(cameraRig && hero){
+    const target = new THREE.Vector3(hero.position.x, 0, hero.position.z);
+    cameraRig.position.lerp(target, Math.min(1, dt * 5));
+  }
+}
+
+export function setTileColor(x, z, hex){
+  if(!tileMesh) return;
+  const index = z * width + x;
+  tileMesh.setColorAt(index, color.setHex(hex));
+  tileColors[index] = hex;
+  tileMesh.instanceColor.needsUpdate = true;
+}
+
+export function getTileColor(x, z){
+  const index = z * width + x;
+  return tileColors[index];
+}
+
+export function raycastTile(ndcX, ndcY, camera){
+  if(!tileMesh) return null;
+  raycaster.setFromCamera({x:ndcX, y:ndcY}, camera);
+  const hit = raycaster.intersectObject(tileMesh, true)[0];
+  if(!hit) return null;
+  const p = hit.point;
+  const tx = Math.floor(p.x);
+  const tz = Math.floor(p.z);
+  if(tx<0||tz<0||tx>=width||tz>=depth) return null;
+  return { x: tx, z: tz, index: tz*width + tx };
+}
+
+export function getHeroWorldPos(){
+  return hero ? hero.position.clone() : new THREE.Vector3();
+}
+
+export function moveHeroToTile(x, z){
+  if(!hero) return;
+  hero.position.set(x + 0.5, 0.3, z + 0.5);
+}


### PR DESCRIPTION
## Summary
- add renderer.js with WebGL renderer, scene, camera rig, and default lighting
- add world3d.js to build instanced tile world and hero mesh with helpers
- add controls.js for grid movement and camera rotation

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68c5f07f80b08327ba713018620249d6