### PR TITLE
Add 3D tile hover and selection utilities

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,8 @@ import { CombatSystem } from './combat.js';
 import { pushBubble, pushActions, showToast, updatePartyUI, updateInventoryUI, gridLayer } from './ui.js';
 import { getSelectedText } from './selection.js';
 import { talkToNPC } from './ai.js';
+import { renderer, scene, camera } from './renderer.js';
+import { raycastTileFromScreen, setHighlightGrid, hideHighlight, updateHighlight } from './world3d.js';
 
 const dpr = Math.min(window.devicePixelRatio||1, 2);
 const skyC = document.getElementById('sky'), sky = skyC.getContext('2d');
@@ -344,3 +346,37 @@ function loop(){
   }
 }
 requestAnimationFrame(loop);
+
+function moveHeroToTile(x, z){
+  console.log('moveHeroToTile', x, z);
+}
+
+if (renderer && renderer.domElement){
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  const dom = renderer.domElement;
+  dom.addEventListener('pointermove', e => {
+    const rect = dom.getBoundingClientRect();
+    const nx = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const ny = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    const hit = raycastTileFromScreen(nx, ny, camera);
+    if(hit) setHighlightGrid(hit.gridX, hit.gridZ);
+    else hideHighlight();
+  });
+
+  dom.addEventListener('click', e => {
+    const rect = dom.getBoundingClientRect();
+    const nx = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const ny = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    const hit = raycastTileFromScreen(nx, ny, camera);
+    if(hit) moveHeroToTile(hit.gridX, hit.gridZ);
+  });
+
+  function loop3d(){
+    requestAnimationFrame(loop3d);
+    updateHighlight();
+    renderer.render(scene, camera);
+  }
+  loop3d();
+}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/character.test.js",{"duration":5.154188000000033,"failed":false}],[":tests/spellbook.test.js",{"duration":3.9899500000000216,"failed":false}],[":tests/selection.test.js",{"duration":3.860134999999957,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/character.test.js",{"duration":8.20548100000002,"failed":false}],[":tests/spellbook.test.js",{"duration":4.7439860000000635,"failed":false}],[":tests/selection.test.js",{"duration":3.0503269999999816,"failed":false}]]}

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,15 @@
+import * as THREE from 'three';
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.domElement.style.position = 'absolute';
+renderer.domElement.style.top = '0';
+renderer.domElement.style.left = '0';
+
+const scene = new THREE.Scene();
+
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.set(0, 5, 5);
+camera.lookAt(0, 0, 0);
+
+export { renderer, scene, camera };

--- a/world3d.js
+++ b/world3d.js
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+import { scene } from './renderer.js';
+
+const W = 64;
+const H = 64;
+const TILE = 1;
+
+function getInstanceIndexForGrid(x, z) {
+  return z * W + x;
+}
+
+const raycaster = new THREE.Raycaster();
+const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+
+const geo = new THREE.PlaneGeometry(TILE * 1.05, TILE * 1.05);
+geo.rotateX(-Math.PI / 2);
+const mat = new THREE.MeshStandardMaterial({ color: 0xffff00, emissive: 0xffff66, transparent: true, opacity: 0, depthWrite: false });
+const highlight = new THREE.Mesh(geo, mat);
+highlight.position.y = 0.01;
+highlight.renderOrder = 999;
+highlight.castShadow = false;
+highlight.receiveShadow = false;
+scene.add(highlight);
+
+let targetOpacity = 0;
+export function setHighlightGrid(x, z) {
+  highlight.position.set((x - W / 2 + 0.5) * TILE, 0.01, (z - H / 2 + 0.5) * TILE);
+  targetOpacity = 0.6;
+}
+export function hideHighlight() {
+  targetOpacity = 0;
+}
+export function updateHighlight() {
+  mat.opacity += (targetOpacity - mat.opacity) * 0.2;
+  highlight.visible = mat.opacity > 0.01;
+}
+
+export function raycastTileFromScreen(x, y, camera) {
+  raycaster.setFromCamera({ x, y }, camera);
+  const hit = new THREE.Vector3();
+  if (!raycaster.ray.intersectPlane(plane, hit)) return null;
+  const gridX = Math.floor(hit.x / TILE + W / 2);
+  const gridZ = Math.floor(hit.z / TILE + H / 2);
+  if (gridX < 0 || gridX >= W || gridZ < 0 || gridZ >= H) return null;
+  return { index: getInstanceIndexForGrid(gridX, gridZ), gridX, gridZ };
+}
+
+export { getInstanceIndexForGrid };


### PR DESCRIPTION
## Summary
- export reusable Three.js renderer, scene and camera
- add tile raycasting and highlight helpers for grid selection
- wire pointer hover/click to highlight tiles and invoke moveHeroToTile

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_68c5f1889bc083278e70116c2a6c3194