### PR TITLE
Add tile selection and hover highlight

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,9 @@ import { CombatSystem } from './combat.js';
 import { pushBubble, pushActions, showToast, updatePartyUI, updateInventoryUI, gridLayer } from './ui.js';
 import { getSelectedText } from './selection.js';
 import { talkToNPC } from './ai.js';
+import { initRenderer, renderer, scene, camera, render } from './renderer.js';
+import { initWorld3D, updateWorld3D, raycastTileFromScreen, setHighlightGrid, hideHighlight, moveHeroToTile } from './world3d.js';
+import { initControls, updateControls } from './controls.js';
 
 const dpr = Math.min(window.devicePixelRatio||1, 2);
 const skyC = document.getElementById('sky'), sky = skyC.getContext('2d');
@@ -344,3 +347,29 @@ function loop(){
   }
 }
 requestAnimationFrame(loop);
+
+// 3D tile demo
+const { cameraRig } = initRenderer();
+const { world } = initWorld3D(8,8);
+scene.add(world);
+initControls({ width:8, depth:8, cameraRig });
+
+let last3d = performance.now();
+function loop3d(now){
+  requestAnimationFrame(loop3d);
+  const dt = (now - last3d)/1000; last3d = now;
+  updateControls(dt);
+  updateWorld3D(dt);
+  render();
+}
+requestAnimationFrame(loop3d);
+
+renderer.domElement.addEventListener('pointermove', e=>{
+  const hit = raycastTileFromScreen(e.clientX, e.clientY, camera);
+  if(hit) setHighlightGrid(hit.gridX, hit.gridZ);
+  else hideHighlight();
+});
+renderer.domElement.addEventListener('click', e=>{
+  const hit = raycastTileFromScreen(e.clientX, e.clientY, camera);
+  if(hit) moveHeroToTile(hit.gridX, hit.gridZ);
+});

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-let renderer, scene, camera, cameraRig;
+export let renderer, scene, camera, cameraRig;
 
 export function initRenderer(container=document.body){
   renderer = new THREE.WebGLRenderer({ antialias:true });


### PR DESCRIPTION
## Summary
- add InstancedMesh tile raycasting and highlight mesh
- export renderer internals for selection math
- demo mouse hover and click to move hero

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_68c5f35469388327b1856b76736cdf38