### PR TITLE
Fix: remove duplicate export of cameraRig in renderer.js

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -49,5 +49,3 @@ export function render() {
     renderer.render(scene, camera);
   }
 }
-
-export { renderer, scene, camera, cameraRig };


### PR DESCRIPTION
## Summary
- remove the duplicate export statement for the renderer module variables to avoid syntax errors

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68caaaa9f0d8832790ac17a5dec355d6