### PR TITLE
Fix ES module loading and bootstrap resilience

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Project: Britannia Reborn — Prototype</title>
   <link rel="stylesheet" href="style.css" />
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/"
+      }
+    }
+  </script>
 </head>
 <body>
   <div id="root">
@@ -52,11 +60,89 @@
     <div class="watermark">Local ES‑Modules Prototype — AI optional via server</div>
   </div>
 
-  <script type="module" src="./main.js" id="game-script"></script>
   <script>
-    // simple cache bust during dev
-    const s = document.getElementById('game-script');
-    if (s && !/\?v=/.test(s.src)) s.src += (s.src.includes('?') ? '&' : '?') + 'v=' + Date.now();
+    (() => {
+      const root = document.getElementById('root') || document.body;
+      const showBootError = (message, error) => {
+        console.error('[Boot]', message, error);
+        const overlayId = 'boot-error-overlay';
+        let overlay = document.getElementById(overlayId);
+        if (!overlay) {
+          overlay = document.createElement('div');
+          overlay.id = overlayId;
+          overlay.style.position = 'fixed';
+          overlay.style.inset = '0';
+          overlay.style.zIndex = '2000';
+          overlay.style.background = 'rgba(5, 10, 22, 0.94)';
+          overlay.style.display = 'flex';
+          overlay.style.flexDirection = 'column';
+          overlay.style.alignItems = 'center';
+          overlay.style.justifyContent = 'center';
+          overlay.style.padding = '32px';
+          overlay.style.textAlign = 'center';
+          overlay.style.color = '#fff';
+          overlay.style.fontFamily = 'Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial';
+          overlay.style.gap = '16px';
+          (root || document.body).appendChild(overlay);
+        }
+
+        overlay.replaceChildren();
+        const title = document.createElement('h2');
+        title.textContent = 'Unable to start Britannia Reborn';
+        overlay.appendChild(title);
+
+        const messageEl = document.createElement('p');
+        messageEl.textContent = message;
+        overlay.appendChild(messageEl);
+
+        if (error) {
+          const details = document.createElement('pre');
+          details.textContent = (error && error.stack) || String(error);
+          details.style.maxWidth = '680px';
+          details.style.maxHeight = '240px';
+          details.style.overflow = 'auto';
+          details.style.margin = '0';
+          details.style.textAlign = 'left';
+          details.style.background = 'rgba(0, 0, 0, 0.45)';
+          details.style.padding = '16px';
+          details.style.borderRadius = '12px';
+          overlay.appendChild(details);
+        }
+
+        const hint = document.createElement('p');
+        hint.textContent = 'Please check your connection and reload the page. If the issue persists, see the browser console for details or try adding ?dev=1 to the URL to reset cached files.';
+        overlay.appendChild(hint);
+      };
+
+      window.__britanniaShowBootError = showBootError;
+
+      window.addEventListener('error', (event) => {
+        const target = event.target;
+        if (target && target.tagName === 'SCRIPT') {
+          showBootError(`Failed to load ${target.src || 'a required script'}.`, event.error || event.message);
+        }
+      }, true);
+
+      window.addEventListener('unhandledrejection', (event) => {
+        showBootError('A critical error occurred while starting the game.', event.reason);
+      });
+    })();
+  </script>
+
+  <script type="module" id="game-script">
+    const showBootError = window.__britanniaShowBootError || ((message, error) => console.error(message, error));
+    const moduleUrl = new URL('./main.js', import.meta.url);
+    const pageParams = new URLSearchParams(window.location.search);
+    const forcedVersion = pageParams.get('v');
+    if (forcedVersion) {
+      moduleUrl.searchParams.set('v', forcedVersion);
+    } else if (!moduleUrl.searchParams.has('v')) {
+      moduleUrl.searchParams.set('v', Date.now().toString());
+    }
+
+    import(moduleUrl.href).catch((error) => {
+      showBootError('Failed to load the game module.', error);
+    });
   </script>
 
   <script type="module">
@@ -66,7 +152,7 @@
     // Use a fixed build tag so the service worker file path doesn't change on
     // every page load, which would trigger perpetual reloads. Bump this value
     // when the service worker itself changes to force an update.
-    const buildTag = '1';
+    const buildTag = '2';
 
     if ('serviceWorker' in navigator) {
       if (isDev) {
@@ -84,6 +170,8 @@
               }
             });
           });
+        }).catch(err => {
+          console.warn('[SW] Registration failed; continuing without offline support.', err);
         });
 
         navigator.serviceWorker.addEventListener('controllerchange', () => {

--- a/renderer.js
+++ b/renderer.js
@@ -2,7 +2,15 @@ import * as THREE from 'three';
 
 export let renderer, scene, camera, cameraRig;
 
-export function initRenderer(container = document.body) {
+export function initRenderer(container = null) {
+  let target = container || document.body;
+  if (!target) {
+    target = document.getElementById('root');
+  }
+  if (!target) {
+    throw new Error('Renderer container element was not found.');
+  }
+
   renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -10,10 +18,18 @@ export function initRenderer(container = document.body) {
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   renderer.setPixelRatio(window.devicePixelRatio || 1);
   renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.domElement.id = 'world3d-canvas';
   renderer.domElement.style.position = 'absolute';
   renderer.domElement.style.top = '0';
   renderer.domElement.style.left = '0';
-  container.appendChild(renderer.domElement);
+  if (!renderer.domElement.isConnected) {
+    const existing = document.getElementById('world3d-canvas');
+    if (existing && existing !== renderer.domElement) {
+      existing.replaceWith(renderer.domElement);
+    } else {
+      target.appendChild(renderer.domElement);
+    }
+  }
 
   scene = new THREE.Scene();
 


### PR DESCRIPTION
## Summary
- add an import map so three.js resolves from a CDN and guard module bootstrap with a user-facing error overlay
- dynamically import the main module with cache busting, bump the service worker build tag, and log registration failures instead of surfacing console errors
- ensure the WebGL renderer canvas is attached to an existing container and replace any stale instance to keep the DOM consistent

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68caae4c1320832799671e176c488068