### PR TITLE
Fix duplicate world3d exports and stabilize service worker caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
-const CACHE_VERSION = new URL(self.location).searchParams.get('v') || `${self.registration.scope}-${Date.now()}`;
-const CACHE_NAME = `br-cache-${CACHE_VERSION}`;
-const ASSETS = [
+const SCRIPT_VERSION = new URL(self.location).searchParams.get('v') || 'static';
+const CACHE_NAME = `br-cache-${SCRIPT_VERSION}`;
+const PRECACHE_URLS = [
   './',
   './index.html',
   './main.js',
@@ -18,11 +18,30 @@ const ASSETS = [
   './controls.js'
 ];
 
+const isSameOrigin = (url) => {
+  try {
+    return new URL(url).origin === self.location.origin;
+  } catch {
+    return false;
+  }
+};
+
+const canCacheResponse = (response) => response && ['basic', 'cors'].includes(response.type);
+
+async function cachePutSafe(cache, request, response) {
+  if (!response || !canCacheResponse(response)) return;
+  try {
+    await cache.put(request, response.clone());
+  } catch (err) {
+    console.warn('[SW] Failed to update cache for', request.url, err);
+  }
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
     const cache = await caches.open(CACHE_NAME);
     try {
-      await cache.addAll(ASSETS.map(u => new Request(u, { cache: 'reload' })));
+      await cache.addAll(PRECACHE_URLS.map((url) => new Request(url, { cache: 'reload' })));
     } catch (err) {
       console.warn('[SW] Failed to precache some assets', err);
     }
@@ -33,67 +52,64 @@ self.addEventListener('install', (event) => {
 self.addEventListener('activate', (event) => {
   event.waitUntil((async () => {
     const names = await caches.keys();
-    await Promise.all(names.filter(n => n !== CACHE_NAME).map(n => caches.delete(n)));
+    await Promise.all(names.filter((name) => name !== CACHE_NAME).map((name) => caches.delete(name)));
     await self.clients.claim();
   })());
 });
-
-const isSameOrigin = (url) => new URL(url).origin === location.origin;
 
 self.addEventListener('fetch', (event) => {
   const { request } = event;
   if (request.method !== 'GET' || !isSameOrigin(request.url)) return;
 
-  const url = new URL(request.url);
-  const isHTML = request.mode === 'navigate' || url.pathname.endsWith('/') || url.pathname.endsWith('.html');
-  const isMain = url.pathname.endsWith('/main.js');
-
-  if (isHTML || isMain) {
-    event.respondWith((async () => {
-      try {
-        const fresh = await fetch(request, { cache: 'no-store' });
-        const cache = await caches.open(CACHE_NAME);
-        try {
-          await cache.put(request, fresh.clone());
-        } catch (err) {
-          console.warn('[SW] Failed to update cache for', request.url, err);
-        }
-        return fresh;
-      } catch {
-        const cache = await caches.open(CACHE_NAME);
-        const cached = await cache.match(request);
-        return cached || new Response('Offline', {
-          status: 503,
-          statusText: 'Offline',
-          headers: { 'Content-Type': 'text/plain' }
-        });
-      }
-    })());
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigationRequest(request));
     return;
   }
 
-  event.respondWith((async () => {
-    const cache = await caches.open(CACHE_NAME);
-    const cached = await cache.match(request);
-    if (cached) return cached;
-    try {
-      const fresh = await fetch(request);
-      try {
-        await cache.put(request, fresh.clone());
-      } catch (err) {
-        console.warn('[SW] Failed to cache', request.url, err);
-      }
-      return fresh;
-    } catch {
-      return cached || new Response('', {
-        status: 503,
-        statusText: 'Service Unavailable'
-      });
-    }
-  })());
+  event.respondWith(handleAssetRequest(request));
 });
+
+async function handleNavigationRequest(request) {
+  const cache = await caches.open(CACHE_NAME);
+  try {
+    const response = await fetch(request, { cache: 'no-store' });
+    await cachePutSafe(cache, request, response);
+    return response;
+  } catch (err) {
+    const fallback = (await cache.match(request)) || (await cache.match('./index.html'));
+    if (fallback) {
+      return fallback;
+    }
+    return new Response('Offline', {
+      status: 503,
+      statusText: 'Offline',
+      headers: { 'Content-Type': 'text/plain' }
+    });
+  }
+}
+
+async function handleAssetRequest(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  if (cached) {
+    fetch(request).then((response) => cachePutSafe(cache, request, response)).catch((err) => {
+      console.warn('[SW] Failed to refresh cached asset', request.url, err);
+    });
+    return cached;
+  }
+
+  try {
+    const response = await fetch(request);
+    await cachePutSafe(cache, request, response);
+    return response;
+  } catch (err) {
+    return new Response('', {
+      status: 503,
+      statusText: 'Service Unavailable'
+    });
+  }
+}
 
 self.addEventListener('message', (event) => {
   if (event.data === 'SKIP_WAITING') self.skipWaiting();
 });
-


### PR DESCRIPTION
## Summary
- refactor world3d utilities into a single implementation with bounds checks and highlight state resets
- guard 3D tile raycasting/highlight against uninitialised renderer instances
- harden the service worker fetch strategy with safe caching helpers and navigation fallbacks to avoid rejected responses

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68cab12185c88327ad559a1782fb88f4