### PR TITLE
Add Memory Cue unified tagging dashboard

### DIFF
--- a/memory/index.html
+++ b/memory/index.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Memory Cue — Unified Tagging</title>
+  <link rel="stylesheet" href="./memory.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="app-title">
+        <h1>Memory Cue</h1>
+        <p class="app-subtitle">Unified tagging across reminders, lesson plans, and quick notes.</p>
+      </div>
+      <div class="tag-widget" id="tagPreferenceSnapshot" aria-live="polite"></div>
+    </header>
+
+    <main class="layout-grid">
+      <section class="dashboard" aria-labelledby="dashboard-heading">
+        <h2 id="dashboard-heading">Tag insights</h2>
+        <div class="dashboard-grid">
+          <article class="dashboard-card" aria-labelledby="popular-tags-heading">
+            <div class="dashboard-card-header">
+              <h3 id="popular-tags-heading">Popular tags</h3>
+            </div>
+            <div class="dashboard-card-body" id="popularTagsList"></div>
+          </article>
+
+          <article class="dashboard-card" aria-labelledby="recent-by-tag-heading">
+            <div class="dashboard-card-header">
+              <h3 id="recent-by-tag-heading">Recent items by tag</h3>
+              <label class="tag-select" for="recentTagSelect">Explore tag</label>
+            </div>
+            <div class="dashboard-card-body recent-by-tag">
+              <select id="recentTagSelect" aria-label="Choose tag to view recent items"></select>
+              <ul class="recent-items" id="recentTagItems"></ul>
+            </div>
+          </article>
+
+          <article class="dashboard-card" aria-labelledby="tag-quick-links-heading">
+            <div class="dashboard-card-header">
+              <h3 id="tag-quick-links-heading">Quick tag links</h3>
+              <p class="dashboard-card-subtitle">Jump directly to everything related to a tag.</p>
+            </div>
+            <div class="dashboard-card-body" id="tagQuickLinks"></div>
+          </article>
+        </div>
+      </section>
+
+      <section class="feature" id="remindersSection" aria-labelledby="reminders-heading">
+        <div class="feature-header">
+          <div>
+            <h2 id="reminders-heading">Reminders</h2>
+            <p>Keep classroom follow-ups and deadlines organised.</p>
+          </div>
+          <div class="filter-region" id="remindersFilterRegion"></div>
+        </div>
+        <form id="reminderForm" class="item-form" autocomplete="off">
+          <div class="form-grid">
+            <label>
+              <span>Title</span>
+              <input type="text" name="title" required placeholder="e.g., Email parents about field trip" />
+            </label>
+            <label>
+              <span>Due date</span>
+              <input type="date" name="dueDate" />
+            </label>
+          </div>
+          <label class="full-width">
+            <span>Details</span>
+            <textarea name="details" rows="2" placeholder="Add context or action steps"></textarea>
+          </label>
+          <div class="full-width">
+            <span class="label">Tags</span>
+            <div class="tag-input-slot" id="reminderTagInput"></div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary">Save reminder</button>
+          </div>
+        </form>
+        <div class="active-filters" id="remindersActiveFilters" aria-live="polite"></div>
+        <div class="item-list" id="remindersList" aria-live="polite"></div>
+      </section>
+
+      <section class="feature" id="lessonsSection" aria-labelledby="lessons-heading">
+        <div class="feature-header">
+          <div>
+            <h2 id="lessons-heading">Lesson plans</h2>
+            <p>Tag upcoming lessons and key objectives for quick retrieval.</p>
+          </div>
+          <div class="filter-region" id="lessonsFilterRegion"></div>
+        </div>
+        <form id="lessonForm" class="item-form" autocomplete="off">
+          <div class="form-grid">
+            <label>
+              <span>Lesson title</span>
+              <input type="text" name="title" required placeholder="e.g., Fractions lab" />
+            </label>
+            <label>
+              <span>Grade level</span>
+              <input type="text" name="grade" placeholder="e.g., Grade 3" />
+            </label>
+          </div>
+          <label class="full-width">
+            <span>Overview</span>
+            <textarea name="overview" rows="2" placeholder="Key objectives or materials"></textarea>
+          </label>
+          <div class="full-width">
+            <span class="label">Tags</span>
+            <div class="tag-input-slot" id="lessonTagInput"></div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary">Save lesson plan</button>
+          </div>
+        </form>
+        <div class="active-filters" id="lessonsActiveFilters" aria-live="polite"></div>
+        <div class="item-list" id="lessonsList" aria-live="polite"></div>
+      </section>
+
+      <section class="feature" id="notesSection" aria-labelledby="notes-heading">
+        <div class="feature-header">
+          <div>
+            <h2 id="notes-heading">Quick notes</h2>
+            <p>Capture on-the-fly ideas, student wins, or follow-ups.</p>
+          </div>
+          <div class="filter-region" id="notesFilterRegion"></div>
+        </div>
+        <form id="noteForm" class="item-form" autocomplete="off">
+          <label class="full-width">
+            <span>Title</span>
+            <input type="text" name="title" required placeholder="e.g., Parent meeting recap" />
+          </label>
+          <label class="full-width">
+            <span>Note</span>
+            <textarea name="content" rows="3" placeholder="Details you want to remember"></textarea>
+          </label>
+          <div class="full-width">
+            <span class="label">Tags</span>
+            <div class="tag-input-slot" id="noteTagInput"></div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary">Save note</button>
+          </div>
+        </form>
+        <div class="active-filters" id="notesActiveFilters" aria-live="polite"></div>
+        <div class="item-list" id="notesList" aria-live="polite"></div>
+      </section>
+    </main>
+  </div>
+
+  <template id="emptyStateTemplate">
+    <div class="empty-state">
+      <p class="empty-title"></p>
+      <p class="empty-subtitle"></p>
+    </div>
+  </template>
+
+  <script type="module" src="./memory.js"></script>
+</body>
+</html>

--- a/memory/memory.css
+++ b/memory/memory.css
@@ -1,0 +1,586 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --surface-alt: #eef2fb;
+  --border: #d8e0f0;
+  --text: #1f2a44;
+  --text-muted: #475571;
+  --accent: #3366ff;
+  --accent-soft: rgba(51, 102, 255, 0.12);
+  --chip-bg: rgba(31, 42, 68, 0.08);
+  --chip-border: rgba(31, 42, 68, 0.18);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+}
+
+h1, h2, h3, h4 {
+  margin: 0;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.app-subtitle {
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.tag-widget {
+  min-width: 220px;
+  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 8px 20px -12px rgba(40, 60, 90, 0.35);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.layout-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.dashboard-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 16px 32px -24px rgba(27, 46, 90, 0.4);
+}
+
+.dashboard-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.dashboard-card-subtitle {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dashboard-card-body.recent-by-tag {
+  gap: 16px;
+}
+
+.tag-select {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+#recentTagSelect {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  font-size: 0.95rem;
+}
+
+.recent-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recent-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+}
+
+.recent-item h4 {
+  font-size: 1rem;
+}
+
+.recent-item .meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.feature {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 18px 36px -28px rgba(10, 35, 70, 0.45);
+}
+
+.feature-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.feature-header p {
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.item-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--surface-alt);
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.full-width {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+label span {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+input[type="text"],
+input[type="date"],
+textarea {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+  font-size: 1rem;
+  color: var(--text);
+  transition: border-color 0.2s ease;
+}
+
+input[type="text"]:focus,
+input[type="date"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(51, 102, 255, 0.55);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+button.primary {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary:hover,
+button.primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px -12px rgba(51, 102, 255, 0.7);
+}
+
+.active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 20px;
+}
+
+.item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.item-card {
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 12px 24px -22px rgba(16, 42, 82, 0.4);
+}
+
+.item-card .item-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.item-card .item-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.item-card .item-body {
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.tag-collection {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag-badge,
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+.tag-badge:hover,
+.tag-badge:focus-visible,
+.filter-chip:hover,
+.filter-chip:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px -14px rgba(0, 0, 0, 0.3);
+}
+
+.filter-chip {
+  border: none;
+}
+
+.filter-chip .remove {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.empty-state {
+  border: 1px dashed var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  text-align: center;
+  background: var(--surface-alt);
+  color: var(--text-muted);
+}
+
+.empty-state .empty-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.tag-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  min-height: 44px;
+  padding: 6px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: #fff;
+  position: relative;
+}
+
+.tag-input.focused {
+  border-color: rgba(51, 102, 255, 0.55);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.tag-input input[type="text"] {
+  flex: 1 0 120px;
+  border: none;
+  padding: 8px;
+  min-width: 120px;
+}
+
+.tag-input input[type="text"]:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--chip-bg);
+  color: var(--text);
+  border: 1px solid var(--chip-border);
+  font-size: 0.85rem;
+}
+
+.tag-chip button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.tag-suggestions {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 4px);
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  box-shadow: 0 14px 28px -22px rgba(16, 32, 72, 0.55);
+  padding: 8px 0;
+  z-index: 20;
+  display: none;
+}
+
+.tag-suggestions.visible {
+  display: block;
+}
+
+.tag-suggestions button {
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.tag-suggestions button:hover,
+.tag-suggestions button:focus-visible,
+.tag-suggestions button.active {
+  background: var(--surface-alt);
+}
+
+.tag-suggestions .hint {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.filter-region {
+  position: relative;
+  min-width: 220px;
+}
+
+.tag-filter {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tag-filter-toggle {
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tag-filter-toggle::after {
+  content: '\25BC';
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.tag-filter.open .tag-filter-toggle::after {
+  transform: rotate(180deg);
+}
+
+.tag-filter-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: min(280px, 90vw);
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 32px -24px rgba(15, 35, 70, 0.45);
+  padding: 12px 0;
+  display: none;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 30;
+}
+
+.tag-filter.open .tag-filter-menu {
+  display: block;
+}
+
+.tag-filter-menu label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.tag-filter-menu input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.tag-filter-menu .count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.tag-filter-menu .actions {
+  padding: 12px 16px 4px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tag-filter-menu .actions button {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: none;
+  background: var(--surface-alt);
+  cursor: pointer;
+}
+
+.popular-tag {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.popular-tag .count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.quick-links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quick-links button {
+  border: none;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: var(--surface-alt);
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+}
+
+.quick-links button:hover,
+.quick-links button:focus-visible {
+  background: rgba(51, 102, 255, 0.08);
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 24px 16px 40px;
+  }
+
+  .feature {
+    padding: 20px;
+  }
+}

--- a/memory/memory.js
+++ b/memory/memory.js
@@ -1,0 +1,703 @@
+import { TagManager, normalizeTag, formatTag, presetTags } from './tag-manager.js';
+import { createTagInput } from './tag-input.js';
+
+const STORAGE_KEYS = {
+  items: 'memoryCueItems',
+  filters: 'memoryCueFilters',
+};
+
+const SECTION_CONFIG = {
+  reminders: {
+    formId: 'reminderForm',
+    tagInputId: 'reminderTagInput',
+    listId: 'remindersList',
+    filterRegionId: 'remindersFilterRegion',
+    activeFiltersId: 'remindersActiveFilters',
+    empty: {
+      title: 'No reminders yet',
+      subtitle: 'Add upcoming tasks or communications to stay organised.',
+    },
+  },
+  lessons: {
+    formId: 'lessonForm',
+    tagInputId: 'lessonTagInput',
+    listId: 'lessonsList',
+    filterRegionId: 'lessonsFilterRegion',
+    activeFiltersId: 'lessonsActiveFilters',
+    empty: {
+      title: 'No lesson plans saved',
+      subtitle: 'Capture your next activity and tag it for fast retrieval.',
+    },
+  },
+  notes: {
+    formId: 'noteForm',
+    tagInputId: 'noteTagInput',
+    listId: 'notesList',
+    filterRegionId: 'notesFilterRegion',
+    activeFiltersId: 'notesActiveFilters',
+    empty: {
+      title: 'Quick notes will appear here',
+      subtitle: 'Jot down ideas, wins, or follow-ups and tag them for context.',
+    },
+  },
+};
+
+const tagManager = new TagManager();
+const tagInputs = {};
+const itemsState = loadItems();
+const filtersState = loadFilters();
+
+bootstrap();
+
+function bootstrap() {
+  tagManager.registerTags(presetTags);
+  Object.values(itemsState).forEach((items) => {
+    items.forEach((item) => tagManager.registerTags(item.tags));
+  });
+  setupForms();
+  renderAll();
+  renderDashboard();
+  updatePreferencesSnapshot();
+}
+
+function loadItems() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return getDefaultState();
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEYS.items);
+    if (!raw) {
+      return getDefaultState();
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      reminders: Array.isArray(parsed?.reminders) ? parsed.reminders : [],
+      lessons: Array.isArray(parsed?.lessons) ? parsed.lessons : [],
+      notes: Array.isArray(parsed?.notes) ? parsed.notes : [],
+    };
+  } catch (error) {
+    console.warn('[Memory Cue] Failed to load saved items', error);
+    return getDefaultState();
+  }
+}
+
+function saveItems() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEYS.items, JSON.stringify(itemsState));
+  } catch (error) {
+    console.warn('[Memory Cue] Failed to save items', error);
+  }
+}
+
+function loadFilters() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return { reminders: [], lessons: [], notes: [] };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEYS.filters);
+    if (!raw) {
+      return { reminders: [], lessons: [], notes: [] };
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      reminders: Array.isArray(parsed?.reminders) ? parsed.reminders.map(normalizeTag) : [],
+      lessons: Array.isArray(parsed?.lessons) ? parsed.lessons.map(normalizeTag) : [],
+      notes: Array.isArray(parsed?.notes) ? parsed.notes.map(normalizeTag) : [],
+    };
+  } catch (error) {
+    console.warn('[Memory Cue] Failed to load filters', error);
+    return { reminders: [], lessons: [], notes: [] };
+  }
+}
+
+function saveFilters() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEYS.filters, JSON.stringify(filtersState));
+  } catch (error) {
+    console.warn('[Memory Cue] Failed to save filters', error);
+  }
+}
+
+function getDefaultState() {
+  const now = new Date();
+  const iso = (date) => date.toISOString();
+  return {
+    reminders: [
+      {
+        id: 'rem-1',
+        title: 'Grade math quiz',
+        dueDate: iso(new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000)),
+        details: 'Return graded quizzes to students and flag reteach topics.',
+        tags: ['math', 'grade-3', 'urgent'],
+        createdAt: iso(new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)),
+      },
+      {
+        id: 'rem-2',
+        title: 'Send parent meeting notes',
+        dueDate: iso(new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000)),
+        details: 'Share action plan and next steps with guardians.',
+        tags: ['parent-meeting'],
+        createdAt: iso(new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000)),
+      },
+    ],
+    lessons: [
+      {
+        id: 'lesson-1',
+        title: 'Hands-on fractions lab',
+        grade: 'Grade 3',
+        overview: 'Stations with manipulatives to build fraction fluency.',
+        tags: ['math', 'grade-3'],
+        createdAt: iso(new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000)),
+      },
+      {
+        id: 'lesson-2',
+        title: 'Weather patterns investigation',
+        grade: 'Grade 4',
+        overview: 'Students analyse weather data and craft forecasts.',
+        tags: ['science'],
+        createdAt: iso(new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000)),
+      },
+    ],
+    notes: [
+      {
+        id: 'note-1',
+        title: 'Parent meeting recap — Jordan',
+        content: 'Discussed reading supports and scheduled follow-up call next week.',
+        tags: ['parent-meeting', 'urgent'],
+        createdAt: iso(new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000)),
+      },
+      {
+        id: 'note-2',
+        title: 'STEM night idea',
+        content: 'Invite local engineers to run demo tables for families.',
+        tags: ['science'],
+        createdAt: iso(new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000)),
+      },
+    ],
+  };
+}
+
+function setupForms() {
+  Object.entries(SECTION_CONFIG).forEach(([section, config]) => {
+    const form = document.getElementById(config.formId);
+    const tagSlot = document.getElementById(config.tagInputId);
+    if (!form || !tagSlot) return;
+    const tagInput = createTagInput(tagSlot, {
+      manager: tagManager,
+      placeholder: 'Type a tag and press enter',
+      onChange: () => updatePreferencesSnapshot(),
+    });
+    tagInputs[section] = tagInput;
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const tags = tagInput.getTags();
+      const payload = collectFormData(section, formData, tags);
+      if (!payload) {
+        return;
+      }
+      itemsState[section].unshift(payload);
+      tagManager.registerTags(payload.tags);
+      saveItems();
+      form.reset();
+      tagInput.clear();
+      renderSection(section);
+      renderDashboard();
+      updatePreferencesSnapshot();
+    });
+  });
+}
+
+function collectFormData(section, formData, tags) {
+  const base = {
+    id: `${section}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    tags: tags.map(normalizeTag).filter(Boolean),
+    createdAt: new Date().toISOString(),
+  };
+
+  if (!base.tags.length) {
+    // ensure we keep tags array consistent even if empty
+    base.tags = [];
+  }
+
+  if (section === 'reminders') {
+    const title = String(formData.get('title') || '').trim();
+    if (!title) return null;
+    return {
+      ...base,
+      title,
+      dueDate: formData.get('dueDate') || null,
+      details: String(formData.get('details') || '').trim(),
+    };
+  }
+  if (section === 'lessons') {
+    const title = String(formData.get('title') || '').trim();
+    if (!title) return null;
+    return {
+      ...base,
+      title,
+      grade: String(formData.get('grade') || '').trim(),
+      overview: String(formData.get('overview') || '').trim(),
+    };
+  }
+  if (section === 'notes') {
+    const title = String(formData.get('title') || '').trim();
+    if (!title) return null;
+    return {
+      ...base,
+      title,
+      content: String(formData.get('content') || '').trim(),
+    };
+  }
+  return null;
+}
+
+function renderAll() {
+  Object.keys(SECTION_CONFIG).forEach(renderSection);
+}
+
+function renderSection(section) {
+  renderFilterControls(section);
+  renderActiveFilters(section);
+  renderItems(section);
+}
+
+function renderFilterControls(section) {
+  const config = SECTION_CONFIG[section];
+  const region = document.getElementById(config.filterRegionId);
+  if (!region) return;
+  region.replaceChildren();
+
+  const counts = getTagCountsForSection(section);
+  const filterContainer = document.createElement('div');
+  filterContainer.className = 'tag-filter';
+  if (!counts.length) {
+    const disabledToggle = document.createElement('button');
+    disabledToggle.type = 'button';
+    disabledToggle.className = 'tag-filter-toggle';
+    disabledToggle.textContent = 'No tags yet';
+    disabledToggle.disabled = true;
+    filterContainer.appendChild(disabledToggle);
+    region.appendChild(filterContainer);
+    return;
+  }
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'tag-filter-toggle';
+  const activeCount = filtersState[section]?.length || 0;
+  toggle.textContent = activeCount ? `Tags (${activeCount})` : 'Filter by tags';
+  filterContainer.appendChild(toggle);
+
+  const menu = document.createElement('div');
+  menu.className = 'tag-filter-menu';
+  filterContainer.appendChild(menu);
+
+  counts.forEach(({ tag, count }) => {
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = tag;
+    checkbox.checked = filtersState[section].includes(tag);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        addFilterTag(section, tag);
+      } else {
+        removeFilterTag(section, tag);
+      }
+    });
+    label.appendChild(checkbox);
+    const span = document.createElement('span');
+    span.textContent = formatTag(tag);
+    label.appendChild(span);
+    const countEl = document.createElement('span');
+    countEl.className = 'count';
+    countEl.textContent = `(${count})`;
+    label.appendChild(countEl);
+    menu.appendChild(label);
+  });
+
+  const actions = document.createElement('div');
+  actions.className = 'actions';
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.textContent = 'Clear filters';
+  clearBtn.addEventListener('click', () => {
+    setFilter(section, []);
+    filterContainer.classList.remove('open');
+  });
+  actions.appendChild(clearBtn);
+  menu.appendChild(actions);
+
+  const closeMenu = (event) => {
+    if (!filterContainer.contains(event.target)) {
+      filterContainer.classList.remove('open');
+      document.removeEventListener('click', closeMenu);
+    }
+  };
+
+  toggle.addEventListener('click', (event) => {
+    event.stopPropagation();
+    const isOpen = filterContainer.classList.toggle('open');
+    if (isOpen) {
+      document.addEventListener('click', closeMenu);
+    } else {
+      document.removeEventListener('click', closeMenu);
+    }
+  });
+
+  region.appendChild(filterContainer);
+}
+
+function renderActiveFilters(section) {
+  const config = SECTION_CONFIG[section];
+  const container = document.getElementById(config.activeFiltersId);
+  if (!container) return;
+  container.replaceChildren();
+  const active = filtersState[section] || [];
+  if (!active.length) return;
+
+  active.forEach((tag) => {
+    const chip = document.createElement('span');
+    chip.className = 'filter-chip';
+    chip.style.backgroundColor = tagManager.getTagColor(tag);
+    chip.textContent = formatTag(tag);
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'remove';
+    remove.setAttribute('aria-label', `Remove filter ${formatTag(tag)}`);
+    remove.textContent = '×';
+    remove.addEventListener('click', () => {
+      removeFilterTag(section, tag);
+    });
+    chip.appendChild(remove);
+    container.appendChild(chip);
+  });
+}
+
+function renderItems(section) {
+  const config = SECTION_CONFIG[section];
+  const container = document.getElementById(config.listId);
+  if (!container) return;
+  container.replaceChildren();
+
+  const filters = filtersState[section] || [];
+  const items = (itemsState[section] || []).slice().filter((item) => {
+    if (!filters.length) return true;
+    const itemTags = item.tags || [];
+    return filters.every((filterTag) => itemTags.includes(filterTag));
+  });
+
+  if (!items.length) {
+    const template = document.getElementById('emptyStateTemplate');
+    if (template && 'content' in template) {
+      const clone = template.content.firstElementChild.cloneNode(true);
+      const title = clone.querySelector('.empty-title');
+      const subtitle = clone.querySelector('.empty-subtitle');
+      if (title) title.textContent = config.empty.title;
+      if (subtitle) subtitle.textContent = filters.length
+        ? 'No items match the selected tags yet.'
+        : config.empty.subtitle;
+      container.appendChild(clone);
+      return;
+    }
+  }
+
+  items
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .forEach((item) => {
+      const card = createItemCard(section, item);
+      container.appendChild(card);
+    });
+}
+
+function createItemCard(section, item) {
+  const card = document.createElement('article');
+  card.className = 'item-card';
+
+  const header = document.createElement('div');
+  header.className = 'item-header';
+  const title = document.createElement('h3');
+  title.textContent = item.title;
+  header.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'item-meta';
+  const createdLabel = document.createElement('span');
+  createdLabel.textContent = `Saved ${formatDate(item.createdAt)}`;
+  meta.appendChild(createdLabel);
+
+  if (section === 'reminders' && item.dueDate) {
+    const due = document.createElement('span');
+    due.textContent = `Due ${formatDate(item.dueDate)}`;
+    meta.appendChild(due);
+  }
+  if (section === 'lessons' && item.grade) {
+    const grade = document.createElement('span');
+    grade.textContent = item.grade;
+    meta.appendChild(grade);
+  }
+
+  header.appendChild(meta);
+  card.appendChild(header);
+
+  const bodyText =
+    section === 'reminders' ? item.details : section === 'lessons' ? item.overview : item.content;
+  if (bodyText) {
+    const body = document.createElement('div');
+    body.className = 'item-body';
+    body.textContent = bodyText;
+    card.appendChild(body);
+  }
+
+  if (item.tags?.length) {
+    const tagsRow = document.createElement('div');
+    tagsRow.className = 'tag-collection';
+    item.tags.forEach((tag) => {
+      const badge = createTagBadge(tag, { section });
+      tagsRow.appendChild(badge);
+    });
+    card.appendChild(tagsRow);
+  }
+
+  return card;
+}
+
+function createTagBadge(tag, { section, onClick } = {}) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tag-badge';
+  const color = tagManager.getTagColor(tag);
+  button.style.backgroundColor = color;
+  button.textContent = formatTag(tag);
+  button.addEventListener('click', () => {
+    if (typeof onClick === 'function') {
+      onClick(tag);
+    } else if (section) {
+      addFilterTag(section, tag);
+    }
+  });
+  return button;
+}
+
+function addFilterTag(section, rawTag) {
+  const tag = normalizeTag(rawTag);
+  if (!tag) return;
+  const list = filtersState[section] || (filtersState[section] = []);
+  if (!list.includes(tag)) {
+    list.push(tag);
+    saveFilters();
+    renderSection(section);
+  }
+}
+
+function removeFilterTag(section, rawTag) {
+  const tag = normalizeTag(rawTag);
+  const list = filtersState[section] || (filtersState[section] = []);
+  const idx = list.indexOf(tag);
+  if (idx >= 0) {
+    list.splice(idx, 1);
+    saveFilters();
+    renderSection(section);
+  }
+}
+
+function setFilter(section, tags) {
+  filtersState[section] = Array.from(new Set(tags.map(normalizeTag).filter(Boolean)));
+  saveFilters();
+  renderSection(section);
+}
+
+function getTagCountsForSection(section) {
+  const counts = new Map();
+  (itemsState[section] || []).forEach((item) => {
+    (item.tags || []).forEach((tag) => {
+      const normalized = normalizeTag(tag);
+      if (!normalized) return;
+      counts.set(normalized, (counts.get(normalized) || 0) + 1);
+    });
+  });
+  return Array.from(counts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.tag.localeCompare(b.tag);
+    });
+}
+
+function aggregateTagUsage() {
+  const usage = new Map();
+  Object.entries(itemsState).forEach(([section, items]) => {
+    items.forEach((item) => {
+      (item.tags || []).forEach((tag) => {
+        const normalized = normalizeTag(tag);
+        if (!normalized) return;
+        if (!usage.has(normalized)) {
+          usage.set(normalized, {
+            tag: normalized,
+            total: 0,
+            perSection: { reminders: 0, lessons: 0, notes: 0 },
+            items: [],
+          });
+        }
+        const entry = usage.get(normalized);
+        entry.total += 1;
+        entry.perSection[section] = (entry.perSection[section] || 0) + 1;
+        entry.items.push({ section, item });
+      });
+    });
+  });
+
+  usage.forEach((entry) => {
+    entry.items.sort((a, b) => new Date(b.item.createdAt).getTime() - new Date(a.item.createdAt).getTime());
+  });
+
+  return Array.from(usage.values()).sort((a, b) => {
+    if (b.total !== a.total) return b.total - a.total;
+    return a.tag.localeCompare(b.tag);
+  });
+}
+
+function renderDashboard() {
+  const popularContainer = document.getElementById('popularTagsList');
+  const recentSelect = document.getElementById('recentTagSelect');
+  const recentItemsContainer = document.getElementById('recentTagItems');
+  const quickLinksContainer = document.getElementById('tagQuickLinks');
+
+  const aggregate = aggregateTagUsage();
+
+  if (popularContainer) {
+    popularContainer.replaceChildren();
+    aggregate.slice(0, 6).forEach((entry) => {
+      const row = document.createElement('div');
+      row.className = 'popular-tag';
+      const badge = createTagBadge(entry.tag, { onClick: (tag) => applyGlobalTagFilter(tag) });
+      const count = document.createElement('span');
+      count.className = 'count';
+      count.textContent = `${entry.total} item${entry.total === 1 ? '' : 's'}`;
+      row.appendChild(badge);
+      row.appendChild(count);
+      popularContainer.appendChild(row);
+    });
+    if (!aggregate.length) {
+      popularContainer.textContent = 'Tag something to see insights here.';
+    }
+  }
+
+  if (recentSelect && recentItemsContainer) {
+    const previousValue = recentSelect.value;
+    recentSelect.replaceChildren();
+    aggregate.forEach((entry) => {
+      const option = document.createElement('option');
+      option.value = entry.tag;
+      option.textContent = `${formatTag(entry.tag)} (${entry.total})`;
+      recentSelect.appendChild(option);
+    });
+    if (!aggregate.length) {
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'No tags yet';
+      recentSelect.appendChild(option);
+      recentSelect.disabled = true;
+      recentSelect.value = '';
+      recentSelect.onchange = null;
+      recentItemsContainer.replaceChildren();
+    } else {
+      recentSelect.disabled = false;
+      const selected = aggregate.some((entry) => entry.tag === previousValue)
+        ? previousValue
+        : aggregate[0].tag;
+      recentSelect.value = selected;
+      renderRecentItemsByTag(selected, aggregate, recentItemsContainer);
+      recentSelect.onchange = (event) => {
+        renderRecentItemsByTag(event.target.value, aggregate, recentItemsContainer);
+      };
+    }
+  }
+
+  if (quickLinksContainer) {
+    quickLinksContainer.replaceChildren();
+    if (!aggregate.length) {
+      quickLinksContainer.textContent = 'Quick links will appear once you add a tagged item.';
+    } else {
+      const list = document.createElement('div');
+      list.className = 'quick-links';
+      aggregate.slice(0, 5).forEach((entry) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.innerHTML = `<span>${formatTag(entry.tag)}</span><span>${entry.total} item${entry.total === 1 ? '' : 's'}</span>`;
+        button.addEventListener('click', () => applyGlobalTagFilter(entry.tag));
+        list.appendChild(button);
+      });
+      quickLinksContainer.appendChild(list);
+    }
+  }
+}
+
+function renderRecentItemsByTag(tag, aggregate, container) {
+  container.replaceChildren();
+  const entry = aggregate.find((value) => value.tag === tag);
+  if (!entry) {
+    const message = document.createElement('li');
+    message.textContent = 'No items for this tag yet.';
+    container.appendChild(message);
+    return;
+  }
+  entry.items.slice(0, 4).forEach(({ section, item }) => {
+    const li = document.createElement('li');
+    li.className = 'recent-item';
+    const title = document.createElement('h4');
+    title.textContent = item.title;
+    li.appendChild(title);
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.textContent = `${capitalize(section)} • ${formatDate(item.createdAt)}`;
+    li.appendChild(meta);
+    const viewAll = document.createElement('button');
+    viewAll.type = 'button';
+    viewAll.className = 'tag-badge';
+    viewAll.style.backgroundColor = tagManager.getTagColor(tag);
+    viewAll.textContent = `View all ${formatTag(tag)}`;
+    viewAll.addEventListener('click', () => applyGlobalTagFilter(tag));
+    li.appendChild(viewAll);
+    container.appendChild(li);
+  });
+}
+
+function applyGlobalTagFilter(tag) {
+  Object.keys(SECTION_CONFIG).forEach((section) => {
+    const hasTag = (itemsState[section] || []).some((item) => item.tags?.includes(tag));
+    setFilter(section, hasTag ? [tag] : []);
+  });
+  renderDashboard();
+  updatePreferencesSnapshot();
+}
+
+function formatDate(dateLike) {
+  if (!dateLike) return 'No date';
+  const date = new Date(dateLike);
+  if (Number.isNaN(date.getTime())) return 'No date';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function capitalize(value) {
+  if (!value) return '';
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function updatePreferencesSnapshot() {
+  const snapshot = document.getElementById('tagPreferenceSnapshot');
+  if (!snapshot) return;
+  snapshot.textContent = tagManager.describePreferences();
+}

--- a/memory/tag-input.js
+++ b/memory/tag-input.js
@@ -1,0 +1,244 @@
+import { formatTag, normalizeTag } from './tag-manager.js';
+
+export function createTagInput(container, { manager, placeholder = 'Add tag', initialTags = [], onChange } = {}) {
+  if (!container) {
+    throw new Error('Tag input requires a container element.');
+  }
+  if (!manager) {
+    throw new Error('Tag input requires a TagManager instance.');
+  }
+
+  const root = document.createElement('div');
+  root.className = 'tag-input';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = placeholder;
+  input.setAttribute('aria-label', placeholder);
+  root.appendChild(input);
+
+  const suggestionsEl = document.createElement('div');
+  suggestionsEl.className = 'tag-suggestions';
+  root.appendChild(suggestionsEl);
+
+  container.replaceChildren(root);
+
+  const tags = [];
+  let suggestionItems = [];
+  let activeIndex = -1;
+  let suppressBlur = false;
+
+  function notifyChange() {
+    if (typeof onChange === 'function') {
+      onChange(tags.slice());
+    }
+  }
+
+  function renderChips() {
+    root.querySelectorAll('.tag-chip').forEach((chip) => chip.remove());
+    tags.forEach((tag) => {
+      const chip = document.createElement('span');
+      chip.className = 'tag-chip';
+      const label = document.createElement('span');
+      label.textContent = formatTag(tag);
+      chip.appendChild(label);
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.setAttribute('aria-label', `Remove tag ${formatTag(tag)}`);
+      remove.textContent = '×';
+      remove.addEventListener('click', () => {
+        removeTag(tag);
+        input.focus();
+      });
+      chip.appendChild(remove);
+      root.insertBefore(chip, input);
+    });
+  }
+
+  function hideSuggestions() {
+    suggestionsEl.classList.remove('visible');
+    suggestionsEl.replaceChildren();
+    suggestionItems = [];
+    activeIndex = -1;
+  }
+
+  function highlight(index) {
+    activeIndex = index;
+    const buttons = suggestionsEl.querySelectorAll('button');
+    buttons.forEach((button, idx) => {
+      if (idx === index) {
+        button.classList.add('active');
+        button.setAttribute('aria-selected', 'true');
+      } else {
+        button.classList.remove('active');
+        button.removeAttribute('aria-selected');
+      }
+    });
+  }
+
+  function showSuggestions(query = '') {
+    const trimmed = query.trim();
+    suggestionItems = manager.getSuggestions(trimmed);
+    suggestionsEl.replaceChildren();
+
+    if (!suggestionItems.length) {
+      if (trimmed) {
+        const tag = normalizeTag(trimmed);
+        if (tag) {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.innerHTML = `<span>${formatTag(tag)}</span><span class="hint">Add new tag</span>`;
+          button.addEventListener('click', () => {
+            addTag(tag);
+            hideSuggestions();
+            input.value = '';
+            input.focus();
+          });
+          suggestionsEl.appendChild(button);
+          suggestionItems = [{ tag, isNew: true }];
+          highlight(0);
+          suggestionsEl.classList.add('visible');
+          return;
+        }
+      }
+      hideSuggestions();
+      return;
+    }
+
+    suggestionItems.forEach((item, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.innerHTML = `<span>${formatTag(item.tag)}</span><span class="hint">${item.isNew ? 'Add new tag' : 'Use existing tag'}</span>`;
+      button.addEventListener('mousedown', () => {
+        suppressBlur = true;
+      });
+      button.addEventListener('click', () => {
+        addTag(item.tag);
+        hideSuggestions();
+        input.value = '';
+        input.focus();
+      });
+      suggestionsEl.appendChild(button);
+      if (index === 0) {
+        highlight(0);
+      }
+    });
+
+    suggestionsEl.classList.add('visible');
+  }
+
+  function addTag(rawTag) {
+    const normalized = manager.ensureTag(rawTag);
+    if (!normalized) {
+      return;
+    }
+    if (!tags.includes(normalized)) {
+      tags.push(normalized);
+      renderChips();
+      notifyChange();
+    }
+  }
+
+  function removeTag(rawTag) {
+    const normalized = normalizeTag(rawTag);
+    const idx = tags.indexOf(normalized);
+    if (idx >= 0) {
+      tags.splice(idx, 1);
+      renderChips();
+      notifyChange();
+    }
+  }
+
+  function commitInput(preferredTag) {
+    const value = preferredTag ?? input.value;
+    const normalized = normalizeTag(value);
+    if (!normalized) {
+      input.value = '';
+      return;
+    }
+    addTag(normalized);
+    input.value = '';
+  }
+
+  input.addEventListener('focus', () => {
+    root.classList.add('focused');
+    showSuggestions(input.value);
+  });
+
+  input.addEventListener('blur', () => {
+    setTimeout(() => {
+      root.classList.remove('focused');
+      if (suppressBlur) {
+        suppressBlur = false;
+        return;
+      }
+      hideSuggestions();
+    }, 80);
+  });
+
+  input.addEventListener('input', () => {
+    showSuggestions(input.value);
+  });
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === 'Tab' || event.key === ',') {
+      if (event.key !== 'Tab') {
+        event.preventDefault();
+      }
+      if (activeIndex >= 0 && suggestionItems[activeIndex]) {
+        commitInput(suggestionItems[activeIndex].tag);
+        hideSuggestions();
+      } else {
+        commitInput();
+      }
+      showSuggestions('');
+    } else if (event.key === 'Backspace' && !input.value && tags.length) {
+      event.preventDefault();
+      removeTag(tags[tags.length - 1]);
+    } else if (event.key === 'ArrowDown' && suggestionItems.length) {
+      event.preventDefault();
+      const next = (activeIndex + 1) % suggestionItems.length;
+      highlight(next);
+    } else if (event.key === 'ArrowUp' && suggestionItems.length) {
+      event.preventDefault();
+      const prev = activeIndex <= 0 ? suggestionItems.length - 1 : activeIndex - 1;
+      highlight(prev);
+    } else if (event.key === 'Escape') {
+      hideSuggestions();
+    }
+  });
+
+  suggestionsEl.addEventListener('mouseleave', () => {
+    activeIndex = -1;
+    highlight(-1);
+  });
+
+  setTags(initialTags);
+
+  function setTags(nextTags = []) {
+    tags.splice(0, tags.length);
+    nextTags.forEach((tag) => {
+      const normalized = manager.ensureTag(tag);
+      if (normalized && !tags.includes(normalized)) {
+        tags.push(normalized);
+      }
+    });
+    renderChips();
+    notifyChange();
+  }
+
+  function clear() {
+    setTags([]);
+    input.value = '';
+    hideSuggestions();
+  }
+
+  return {
+    getTags: () => tags.slice(),
+    setTags,
+    clear,
+    focus: () => input.focus(),
+    addTag,
+    removeTag,
+    element: root,
+  };
+}

--- a/memory/tag-manager.js
+++ b/memory/tag-manager.js
@@ -1,0 +1,163 @@
+const DEFAULT_TAGS = ['math', 'science', 'grade-3', 'urgent', 'parent-meeting'];
+const STORAGE_KEY = 'memoryCueTagPrefs';
+
+function readStorage(key) {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    console.warn('[Memory Cue] Unable to read storage', error);
+    return null;
+  }
+}
+
+function writeStorage(key, value) {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('[Memory Cue] Unable to write storage', error);
+  }
+}
+
+export function normalizeTag(rawTag) {
+  if (!rawTag && rawTag !== 0) return '';
+  const str = String(rawTag)
+    .trim()
+    .replace(/^#+/, '')
+    .replace(/[^\p{L}\p{N}-\s]/gu, ' ')
+    .replace(/\s+/g, '-');
+  const normalized = str.replace(/-+/g, '-').replace(/^-|-$/g, '').toLowerCase();
+  return normalized;
+}
+
+export function formatTag(rawTag) {
+  const normalized = normalizeTag(rawTag);
+  return normalized ? `#${normalized}` : '';
+}
+
+function computeColor(tag) {
+  // Deterministic hash -> hue for consistent colours between sessions
+  const normalized = normalizeTag(tag);
+  if (!normalized) {
+    return 'hsl(210, 60%, 55%)';
+  }
+  let hash = 0;
+  for (let i = 0; i < normalized.length; i += 1) {
+    hash = (hash << 5) - hash + normalized.charCodeAt(i);
+    hash |= 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  const saturation = 65;
+  const lightness = 48;
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+}
+
+export class TagManager {
+  constructor({ storageKey = STORAGE_KEY, defaults = DEFAULT_TAGS } = {}) {
+    this.storageKey = storageKey;
+    this.defaults = defaults;
+    this.tags = new Map();
+    this.load();
+  }
+
+  load() {
+    const stored = readStorage(this.storageKey);
+    if (stored && typeof stored === 'object' && stored.colorMap) {
+      Object.entries(stored.colorMap).forEach(([tag, color]) => {
+        if (typeof tag === 'string' && typeof color === 'string') {
+          this.tags.set(tag, { color });
+        }
+      });
+    }
+    this.defaults.forEach((tag) => this.ensureTag(tag));
+    this.persist();
+  }
+
+  persist() {
+    const colorMap = {};
+    this.tags.forEach((value, key) => {
+      colorMap[key] = value.color;
+    });
+    writeStorage(this.storageKey, { colorMap });
+  }
+
+  ensureTag(rawTag) {
+    const tag = normalizeTag(rawTag);
+    if (!tag) return null;
+    if (!this.tags.has(tag)) {
+      this.tags.set(tag, { color: computeColor(tag) });
+      this.persist();
+    }
+    return tag;
+  }
+
+  registerTags(tags = []) {
+    let changed = false;
+    tags.forEach((raw) => {
+      const tag = normalizeTag(raw);
+      if (tag && !this.tags.has(tag)) {
+        this.tags.set(tag, { color: computeColor(tag) });
+        changed = true;
+      }
+    });
+    if (changed) {
+      this.persist();
+    }
+  }
+
+  getTagColor(rawTag) {
+    const tag = normalizeTag(rawTag);
+    if (!tag) {
+      return 'hsl(210, 60%, 55%)';
+    }
+    const entry = this.tags.get(tag);
+    if (entry) {
+      return entry.color;
+    }
+    const color = computeColor(tag);
+    this.tags.set(tag, { color });
+    this.persist();
+    return color;
+  }
+
+  getAllTags() {
+    return Array.from(this.tags.keys()).sort((a, b) => a.localeCompare(b));
+  }
+
+  getSuggestions(inputValue = '', limit = 8) {
+    const query = normalizeTag(inputValue);
+    const suggestions = [];
+    const seen = new Set();
+    const tags = this.getAllTags();
+    tags.forEach((tag) => {
+      if (!query || tag.includes(query)) {
+        if (!seen.has(tag)) {
+          suggestions.push({ tag, isNew: false });
+          seen.add(tag);
+        }
+      }
+    });
+    if (query && !seen.has(query)) {
+      suggestions.push({ tag: query, isNew: !this.tags.has(query) });
+    }
+    return suggestions.slice(0, limit);
+  }
+
+  hasTag(rawTag) {
+    const tag = normalizeTag(rawTag);
+    return !!tag && this.tags.has(tag);
+  }
+
+  describePreferences() {
+    const tags = this.getAllTags();
+    const top = tags.slice(0, 3).map((tag) => formatTag(tag));
+    if (!top.length) {
+      return 'No tags yet. Add some to start organising!';
+    }
+    return `Favourite tags ready: ${top.join(', ')}`;
+  }
+}
+
+export const presetTags = DEFAULT_TAGS.slice();


### PR DESCRIPTION
## Summary
- add a Memory Cue workspace with tag-enabled forms for reminders, lesson plans, and quick notes
- implement shared tag manager, autocomplete tag input, and cross-section tag filtering with analytics widgets
- persist items, tag preferences, and filters in localStorage and display consistent tag badges across the UI

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68cb1eb8e1d08327b5413441158b0cc2