### PR TITLE
Improve canvas focus handling and keyboard debug logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,8 @@
   <div id="root">
     <canvas id="sky"></canvas>
     <canvas id="back"></canvas>
-  <canvas id="game" tabindex="0"></canvas>
-  <canvas id="fx"></canvas>
-  <div id="focusOverlay">Click to refocus · WASD/Arrows to move · Shift+Arrows to look</div>
+    <canvas id="game" tabindex="0"></canvas>
+    <canvas id="fx"></canvas>
     <svg class="gridOverlay" id="gridOverlay"></svg>
     <div class="vignette"></div>
 

--- a/style.css
+++ b/style.css
@@ -7,7 +7,6 @@ html,body{height:100%;margin:0;background:radial-gradient(1200px 800px at 70% -1
 #root{height:100%}
 canvas{display:block;position:absolute;inset:0}
 #game,#hud,#ui{position:absolute;z-index:10;top:0;left:0}
-#focusOverlay{display:none;position:absolute;left:0;top:0;width:100vw;height:100vh;z-index:1000;pointer-events:none;text-align:center;font:16px sans-serif;color:#fff;background:rgba(0,0,0,.25)}
 .vignette{position:absolute;inset:0;pointer-events:none;background:
   radial-gradient(1200px 800px at 50% 30%, #0000 0%, #0000 55%, rgba(0,0,0,.28) 85%, rgba(0,0,0,.6) 100%)}
 .hud{position:absolute;inset:0;pointer-events:none}


### PR DESCRIPTION
## Summary
- autofocus the main game canvas on page load so keyboard input is captured immediately
- add debug logging for key presses and dynamically manage a focus overlay that guides players to refocus the canvas
- remove the static focus overlay markup and rely on inline styling to avoid layout conflicts

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68cb2203b018832788cb3422a6f36e16