### PR TITLE
Improve canvas focus feedback and input logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -191,12 +191,17 @@ function isRefreshCombo(e) {
 
 window.addEventListener('keydown', e => {
   console.log('Key down:', e.key);
+});
+window.addEventListener('keyup', e => {
+  console.log('Key up:', e.key);
+});
+
+window.addEventListener('keydown', e => {
   const key = normalizeKey(e.key);
   keys[key] = true;
   if (!isRefreshCombo(e)) e.preventDefault();
 });
 window.addEventListener('keyup', e => {
-  console.log('Key up:', e.key);
   const key = normalizeKey(e.key);
   keys[key] = false;
   if (!isRefreshCombo(e)) e.preventDefault();
@@ -242,32 +247,25 @@ function createFocusOverlay() {
   if (!overlay) {
     overlay = document.createElement('div');
     overlay.id = 'focusOverlay';
-    overlay.textContent = 'Click to focus game for controls';
-    if (document.body) {
-      document.body.appendChild(overlay);
-    }
-  } else {
-    overlay.textContent = 'Click to focus game for controls';
-    if (!overlay.parentElement && document.body) {
-      document.body.appendChild(overlay);
-    }
   }
-  if (overlay) {
-    Object.assign(overlay.style, {
-      position: 'absolute',
-      top: '10px',
-      left: '50%',
-      transform: 'translateX(-50%)',
-      padding: '8px 12px',
-      background: 'rgba(0,0,0,0.7)',
-      color: '#fff',
-      font: '14px sans-serif',
-      borderRadius: '6px',
-      zIndex: '20',
-      pointerEvents: 'none'
-    });
-    overlay.style.display = 'block';
+  overlay.textContent = 'Click to focus game for controls';
+  if (!overlay.parentElement && document.body) {
+    document.body.appendChild(overlay);
   }
+  Object.assign(overlay.style, {
+    position: 'absolute',
+    top: '10px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    padding: '6px 10px',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#fff',
+    font: '14px sans-serif',
+    borderRadius: '6px',
+    zIndex: '20',
+    pointerEvents: 'none'
+  });
+  overlay.style.display = 'block';
   return overlay;
 }
 


### PR DESCRIPTION
## Summary
- add dedicated debug key listeners so keydown/keyup events visibly log in the console
- refine the focus overlay setup to match the desired styling and ensure it toggles with canvas focus changes

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68cb27ce69a88327a6a8ff9335578746