### PR TITLE
Declare build tag before boot module

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@
   <script type="module" id="game-script">
     const showBootError = window.__britanniaShowBootError || ((message, error) => console.error(message, error));
     const canBoot = window.__BR_CAN_BOOT !== false;
-  // buildTag is provided by the boot script above via __BR_BUILD_TAG
+    // buildTag is provided by the boot script above via __BR_BUILD_TAG
+    const buildTag = window.__BR_BUILD_TAG || '3';
 
     if (canBoot) {
       const moduleUrl = new URL('./main.js', import.meta.url);


### PR DESCRIPTION
## Summary
- declare the `buildTag` constant at the top of the boot module so it is available when setting the main module URL
- ensure the main module import falls back to the same build tag value as other boot scripts

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_b_68cc66e6acd883279ff68a3f43948d30