### PR TITLE
Enhance combat system with interactive commands

### DIFF
--- a/combat.js
+++ b/combat.js
@@ -1,10 +1,41 @@
+import { clamp } from './utils.js';
+
+const DEFAULT_ENCOUNTER = [
+  { id: 'brigand', name: 'Brigand', hp: 18, hpMax: 18, atk: 6, initiative: 12 },
+  { id: 'cutpurse', name: 'Cutpurse', hp: 14, hpMax: 14, atk: 4, initiative: 9 }
+];
+
+const DEFAULT_ENEMY_DELAY = 1.2;
+
+const SPELL_DAMAGE_TABLE = {
+  fire_dart: (caster) => {
+    const intellect = Number.isFinite(caster?.INT) ? caster.INT : 8;
+    return Math.max(6, Math.round(intellect * 1.2 + 6));
+  }
+};
+
+const roundStat = (value, fallback = 0) => {
+  if (!Number.isFinite(value)) return Math.round(fallback);
+  return Math.round(value);
+};
+
 export class CombatSystem {
-  constructor(party) {
+  constructor(party, options = {}) {
     this.party = party;
     this.active = false;
     this.turn = 'player';
+    this.round = 0;
+    this.enemies = [];
     this._listeners = new Set();
     this._enemyTimer = 0;
+    this._pendingEnemyActions = [];
+    this._enemyDelay = Number.isFinite(options.enemyDelay) ? Math.max(0, options.enemyDelay) : DEFAULT_ENEMY_DELAY;
+    this._rng = typeof options.rng === 'function' ? options.rng : Math.random;
+    this._spellbook = options.spellbook ?? null;
+  }
+
+  setSpellbook(spellbook) {
+    this._spellbook = spellbook ?? null;
   }
 
   onEvent(listener) {
@@ -18,44 +49,367 @@ export class CombatSystem {
     }
   }
 
-  startSkirmish() {
+  getState() {
+    return {
+      active: this.active,
+      turn: this.turn,
+      round: this.round,
+      enemies: this.enemies.map((enemy) => ({
+        id: enemy.id,
+        name: enemy.name,
+        hp: roundStat(enemy.hp),
+        hpMax: roundStat(enemy.hpMax),
+        atk: enemy.atk,
+        initiative: enemy.initiative,
+        alive: enemy.hp > 0
+      })),
+      party: Array.isArray(this.party?.members)
+        ? this.party.members.map((member, index) => ({
+            id: member.id ?? `party-${index}`,
+            name: member.name ?? `Member ${index + 1}`,
+            hp: roundStat(member.hp),
+            hpMax: roundStat(member.hpMax ?? member.hp),
+            mp: roundStat(member.mp ?? 0),
+            mpMax: roundStat(member.mpMax ?? member.mp ?? 0),
+            alive: (member.hp ?? 0) > 0
+          }))
+        : []
+    };
+  }
+
+  isPlayerTurn() {
+    return this.active && this.turn === 'player';
+  }
+
+  startSkirmish(roster = DEFAULT_ENCOUNTER) {
     if (this.active) {
       this._emit('log', 'The skirmish is already underway.');
       return false;
     }
+
+    if (!this._hasReadyPartyMember()) {
+      this._emit('log', 'The party is in no shape to fight.');
+      return false;
+    }
+
+    const sanitized = this._prepareRoster(Array.isArray(roster) && roster.length > 0 ? roster : DEFAULT_ENCOUNTER);
+    if (sanitized.length === 0) {
+      this._emit('log', 'There are no foes to engage.');
+      return false;
+    }
+
+    this.enemies = sanitized;
     this.active = true;
     this.turn = 'player';
+    this.round = 1;
+    this._enemyTimer = 0;
+    this._pendingEnemyActions = [];
     this._emit('log', 'Hostile creatures emerge from the brush!');
+    this._emit('state', this.getState());
+    this._emit('turn', { turn: 'player' });
     return true;
   }
 
   endPlayerTurn() {
-    if (!this.active || this.turn !== 'player') {
-      this._emit('log', 'There is no active player turn to end.');
+    if (!this.isPlayerTurn()) {
+      this._emit('log', this.active ? 'It is not the party\'s turn.' : 'There is no active skirmish.');
       return false;
     }
-    this.turn = 'enemy';
-    this._enemyTimer = 1.5;
-    this._emit('log', 'The party braces as the enemy makes their move.');
+    this._prepareEnemyTurn();
     return true;
   }
 
   update(dt) {
-    if (!this.active) return;
-    if (this.turn === 'enemy') {
-      this._enemyTimer -= dt;
-      if (this._enemyTimer <= 0) {
-        this.turn = 'player';
-        this._emit('log', 'The foes regroup; the party may act again.');
-      }
+    if (!this.active || this.turn !== 'enemy') return;
+    this._enemyTimer -= dt;
+    if (this._enemyTimer <= 0) {
+      this._resolveEnemyTurn();
     }
+  }
+
+  playerAttack(targetId) {
+    if (!this.isPlayerTurn()) {
+      const message = this.active ? 'It is not the party\'s turn to act.' : 'No combat is underway.';
+      return { success: false, message };
+    }
+
+    const attacker = this._selectAttacker();
+    if (!attacker) {
+      const message = 'No conscious party members remain to strike.';
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    const target = this._selectEnemy(targetId);
+    if (!target) {
+      const message = 'There are no valid targets.';
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    const damage = this._computePhysicalDamage(attacker);
+    const actualDamage = this._applyEnemyDamage(target, damage);
+    this._emit('log', `${attacker.name} attacks ${target.name} for ${actualDamage} damage.`);
+    if (target.hp <= 0) {
+      this._emit('log', `${target.name} is defeated!`);
+    }
+
+    this._emit('state', this.getState());
+    if (this._checkVictory()) {
+      return { success: true, damage: actualDamage, targetId: target.id, defeated: true };
+    }
+
+    if (this.active) {
+      this._prepareEnemyTurn();
+    }
+
+    return { success: true, damage: actualDamage, targetId: target.id, defeated: target.hp <= 0 };
+  }
+
+  playerCast(spellId, targetId) {
+    if (!this.isPlayerTurn()) {
+      const message = this.active ? 'It is not the party\'s turn to act.' : 'No combat is underway.';
+      return { success: false, message };
+    }
+
+    if (!this._spellbook) {
+      const message = 'No spellbook is available for casting.';
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    const caster = this._selectAttacker();
+    if (!caster) {
+      const message = 'No conscious caster remains.';
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    const spell = this._spellbook.get(spellId);
+    if (!spell) {
+      const message = 'That incantation is unknown.';
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    if (!this._spellbook.canCast(spellId, caster)) {
+      const message = `${caster.name} lacks the means to cast ${spell.name}.`;
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    const target = this._selectEnemy(targetId);
+    if (!target) {
+      const message = 'There are no valid targets.';
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    if (!this._spellbook.cast(spellId, caster)) {
+      const message = `${caster.name} cannot complete the casting of ${spell.name}.`;
+      this._emit('log', message);
+      return { success: false, message };
+    }
+
+    const damage = this._computeSpellDamage(caster, spellId);
+    const actualDamage = this._applyEnemyDamage(target, damage);
+    this._emit('log', `${caster.name} casts ${spell.name} at ${target.name} for ${actualDamage} damage.`);
+    if (target.hp <= 0) {
+      this._emit('log', `${target.name} is reduced to smoldering embers.`);
+    }
+
+    this._emit('state', this.getState());
+    if (this._checkVictory()) {
+      return { success: true, damage: actualDamage, targetId: target.id, defeated: true, spell: spellId };
+    }
+
+    if (this.active) {
+      this._prepareEnemyTurn();
+    }
+
+    return { success: true, damage: actualDamage, targetId: target.id, defeated: target.hp <= 0, spell: spellId };
   }
 
   finish(victory = true) {
     if (!this.active) return;
     this.active = false;
     this.turn = 'player';
+    this._enemyTimer = 0;
+    this._pendingEnemyActions = [];
+    const rewards = victory ? this._calculateRewards() : { xp: 0, gold: 0 };
+    const summary = {
+      victory,
+      rewards,
+      enemies: this.enemies.map((enemy) => ({
+        id: enemy.id,
+        name: enemy.name,
+        defeated: enemy.hp <= 0
+      }))
+    };
     this._emit('log', victory ? 'The skirmish ends in victory.' : 'The party withdraws from battle.');
-    this._emit('complete', { victory });
+    this._emit('complete', summary);
+    this._emit('state', this.getState());
+  }
+
+  _prepareRoster(roster) {
+    return roster
+      .map((enemy, index) => this._sanitizeEnemy(enemy, index))
+      .filter((enemy) => enemy.hp > 0 && enemy.hpMax > 0);
+  }
+
+  _sanitizeEnemy(enemy, index) {
+    const id = typeof enemy?.id === 'string' && enemy.id.length > 0 ? enemy.id : `enemy-${index + 1}`;
+    const name = enemy?.name ?? id;
+    const hpMaxCandidate = Number.isFinite(enemy?.hpMax) ? enemy.hpMax : Number.isFinite(enemy?.hp) ? enemy.hp : 12;
+    const hpMax = Math.max(1, Math.round(hpMaxCandidate));
+    const hpCandidate = Number.isFinite(enemy?.hp) ? enemy.hp : hpMax;
+    const hp = clamp(Math.round(hpCandidate), 0, hpMax);
+    const atk = Number.isFinite(enemy?.atk) ? enemy.atk : 4;
+    const initiative = Number.isFinite(enemy?.initiative) ? enemy.initiative : Math.max(1, 12 - index * 2);
+    return {
+      id,
+      name,
+      hp,
+      hpMax,
+      atk,
+      initiative
+    };
+  }
+
+  _prepareEnemyTurn() {
+    this.turn = 'enemy';
+    this._enemyTimer = this._enemyDelay;
+    this._pendingEnemyActions = this.enemies
+      .filter((enemy) => enemy.hp > 0)
+      .sort((a, b) => (b.initiative ?? 0) - (a.initiative ?? 0));
+    this._emit('log', 'The party braces as the enemy makes their move.');
+    this._emit('state', this.getState());
+    this._emit('turn', { turn: 'enemy' });
+  }
+
+  _resolveEnemyTurn() {
+    if (!this.active) return;
+    for (const enemy of this._pendingEnemyActions) {
+      if (enemy.hp <= 0) continue;
+      const target = this._selectPartyTarget();
+      if (!target) break;
+      const damage = this._computeEnemyDamage(enemy);
+      const actualDamage = this._applyPartyDamage(target, damage);
+      this._emit('log', `${enemy.name} strikes ${target.name} for ${actualDamage} damage.`);
+      if (target.hp <= 0) {
+        this._emit('log', `${target.name} falls unconscious!`);
+      }
+      if (this._checkDefeat()) {
+        this._pendingEnemyActions = [];
+        return;
+      }
+    }
+
+    if (this.active) {
+      this.turn = 'player';
+      this._pendingEnemyActions = [];
+      this._enemyTimer = 0;
+      this.round += 1;
+      this._emit('log', 'The foes regroup; the party may act again.');
+      this._emit('state', this.getState());
+      this._emit('turn', { turn: 'player' });
+    }
+  }
+
+  _selectAttacker() {
+    if (!Array.isArray(this.party?.members)) return null;
+    const leaderIndex = Number.isInteger(this.party.leaderIndex) ? this.party.leaderIndex : 0;
+    const leader = this.party.members[leaderIndex];
+    if (leader && (leader.hp ?? 0) > 0) {
+      return leader;
+    }
+    return this.party.members.find((member) => (member?.hp ?? 0) > 0) ?? null;
+  }
+
+  _selectEnemy(targetId) {
+    if (!Array.isArray(this.enemies) || this.enemies.length === 0) return null;
+    if (targetId) {
+      const found = this.enemies.find((enemy) => enemy.id === targetId && enemy.hp > 0);
+      if (found) return found;
+    }
+    return this.enemies.find((enemy) => enemy.hp > 0) ?? null;
+  }
+
+  _selectPartyTarget() {
+    if (!Array.isArray(this.party?.members)) return null;
+    const byInitiative = this.party.members
+      .map((member, index) => ({ member, index }))
+      .filter(({ member }) => (member?.hp ?? 0) > 0)
+      .sort((a, b) => a.index - b.index);
+    return byInitiative.length > 0 ? byInitiative[0].member : null;
+  }
+
+  _applyEnemyDamage(enemy, amount) {
+    const before = enemy.hp;
+    enemy.hp = clamp(enemy.hp - amount, 0, enemy.hpMax);
+    return Math.max(0, before - enemy.hp);
+  }
+
+  _applyPartyDamage(member, amount) {
+    const before = member.hp ?? 0;
+    member.hp = clamp(before - amount, 0, member.hpMax ?? before);
+    return Math.max(0, before - member.hp);
+  }
+
+  _computePhysicalDamage(attacker) {
+    const strength = Number.isFinite(attacker?.STR) ? attacker.STR : 8;
+    const dexterity = Number.isFinite(attacker?.DEX) ? attacker.DEX : strength;
+    const base = strength * 0.75 + dexterity * 0.25;
+    return Math.max(1, Math.round(base * 0.75));
+  }
+
+  _computeSpellDamage(caster, spellId) {
+    const formula = SPELL_DAMAGE_TABLE[spellId];
+    if (typeof formula === 'function') {
+      return Math.max(1, Math.round(formula(caster)));
+    }
+    return this._computePhysicalDamage(caster) + 4;
+  }
+
+  _computeEnemyDamage(enemy) {
+    const atk = Number.isFinite(enemy?.atk) ? enemy.atk : 4;
+    return Math.max(1, Math.round(atk));
+  }
+
+  _checkVictory() {
+    if (!this.active) return false;
+    const hasLivingEnemy = this.enemies.some((enemy) => enemy.hp > 0);
+    if (!hasLivingEnemy) {
+      this.finish(true);
+      return true;
+    }
+    return false;
+  }
+
+  _checkDefeat() {
+    if (!this.active) return false;
+    const members = Array.isArray(this.party?.members) ? this.party.members : [];
+    const allDown = members.length > 0 && members.every((member) => (member?.hp ?? 0) <= 0);
+    if (allDown) {
+      this.finish(false);
+      return true;
+    }
+    this._emit('state', this.getState());
+    return false;
+  }
+
+  _calculateRewards() {
+    const defeated = this.enemies.filter((enemy) => enemy.hp <= 0).length;
+    if (defeated === 0) {
+      return { xp: 0, gold: 0 };
+    }
+    const xp = defeated * 12;
+    const gold = defeated * 8;
+    return { xp, gold };
+  }
+
+  _hasReadyPartyMember() {
+    if (!Array.isArray(this.party?.members)) return false;
+    return this.party.members.some((member) => (member?.hp ?? 0) > 0);
   }
 }

--- a/style.css
+++ b/style.css
@@ -285,6 +285,83 @@ button:active {
   filter: brightness(0.95);
 }
 
+.panel.combat {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.combat-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #9abef7;
+}
+
+.combat-commands {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.combat-commands .combat-action {
+  flex: 1 1 48%;
+  min-width: 120px;
+}
+
+.combat-enemies {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.combat-enemy {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(18, 34, 54, 0.75);
+  border: 1px solid rgba(120, 168, 220, 0.15);
+  color: #e9f3ff;
+  text-align: left;
+  gap: 12px;
+}
+
+.combat-enemy .name {
+  font-weight: 600;
+}
+
+.combat-enemy .hp {
+  font-size: 12px;
+  color: #9ac4ff;
+}
+
+.combat-enemy.selected {
+  border-color: rgba(255, 216, 120, 0.6);
+  box-shadow: 0 0 0 1px rgba(255, 216, 120, 0.35);
+}
+
+.combat-enemy.defeated {
+  opacity: 0.6;
+  border-color: rgba(160, 72, 72, 0.45);
+}
+
+.combat-enemy.defeated .hp {
+  color: #f3a7a7;
+}
+
+.combat-empty {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(16, 28, 44, 0.7);
+  text-align: center;
+  font-size: 13px;
+  color: #a7b8d8;
+}
+
 .log {
   flex: 1 1 auto;
   display: flex;

--- a/tests/combat.test.js
+++ b/tests/combat.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Party } from '../party.js';
+import { CombatSystem } from '../combat.js';
+import { Inventory } from '../inventory.js';
+import { Spellbook } from '../spells.js';
+
+const createParty = (overrides = {}) => {
+  const baseMember = {
+    name: 'Avatar',
+    STR: 12,
+    DEX: 10,
+    INT: 10,
+    hpMax: 32,
+    hp: 32,
+    mp: 20
+  };
+  return new Party([{ ...baseMember, ...overrides }]);
+};
+
+describe('CombatSystem', () => {
+  let inventory;
+  let party;
+
+  beforeEach(() => {
+    inventory = new Inventory();
+    party = createParty();
+  });
+
+  it('resolves victory when a player attack defeats the last enemy', () => {
+    const spellbook = new Spellbook(inventory, party);
+    const combat = new CombatSystem(party, { spellbook, enemyDelay: 0 });
+    const completions = [];
+    combat.onEvent((event, payload) => {
+      if (event === 'complete') {
+        completions.push(payload);
+      }
+    });
+
+    expect(
+      combat.startSkirmish([
+        { id: 'wolf', name: 'Dire Wolf', hp: 9, hpMax: 9, atk: 4, initiative: 11 }
+      ])
+    ).toBe(true);
+
+    const result = combat.playerAttack('wolf');
+    expect(result.success).toBe(true);
+    expect(result.defeated).toBe(true);
+    expect(combat.getState().active).toBe(false);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].victory).toBe(true);
+  });
+
+  it('processes enemy retaliation that can defeat the party', () => {
+    party = createParty({ hpMax: 16, hp: 16 });
+    const combat = new CombatSystem(party, { enemyDelay: 0 });
+    const completions = [];
+    combat.onEvent((event, payload) => {
+      if (event === 'complete') {
+        completions.push(payload);
+      }
+    });
+
+    expect(
+      combat.startSkirmish([
+        { id: 'ogre', name: 'Ogre', hp: 28, hpMax: 28, atk: 24, initiative: 12 }
+      ])
+    ).toBe(true);
+
+    const result = combat.playerAttack('ogre');
+    expect(result.success).toBe(true);
+    expect(combat.active).toBe(true);
+
+    combat.update(0.01);
+
+    expect(party.members[0].hp).toBe(0);
+    expect(combat.active).toBe(false);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].victory).toBe(false);
+  });
+
+  it('executes enemy actions according to initiative order', () => {
+    const combat = new CombatSystem(party, { enemyDelay: 0 });
+    const logs = [];
+    combat.onEvent((event, payload) => {
+      if (event === 'log') {
+        logs.push(payload);
+      }
+    });
+
+    expect(
+      combat.startSkirmish([
+        { id: 'mage', name: 'Shadow Mage', hp: 24, hpMax: 24, atk: 7, initiative: 16 },
+        { id: 'brute', name: 'Orc Brute', hp: 30, hpMax: 30, atk: 9, initiative: 8 }
+      ])
+    ).toBe(true);
+
+    const attackResult = combat.playerAttack('mage');
+    expect(attackResult.success).toBe(true);
+
+    combat.update(0.01);
+
+    const strikeLogs = logs.filter((entry) =>
+      typeof entry === 'string' && entry.includes('strikes Avatar')
+    );
+    expect(strikeLogs.length).toBeGreaterThanOrEqual(2);
+    expect(strikeLogs[0]).toContain('Shadow Mage');
+    expect(strikeLogs[1]).toContain('Orc Brute');
+  });
+
+  it('allows spellcasting to end a skirmish and consume resources', () => {
+    inventory.add({ id: 'sulfur_ash', name: 'Sulfur Ash', weight: 0.1, qty: 2, tag: 'reagent' });
+    inventory.add({ id: 'black_pearl', name: 'Black Pearl', weight: 0.1, qty: 2, tag: 'reagent' });
+    const spellbook = new Spellbook(inventory, party);
+    const combat = new CombatSystem(party, { spellbook, enemyDelay: 0 });
+    const completions = [];
+    combat.onEvent((event, payload) => {
+      if (event === 'complete') {
+        completions.push(payload);
+      }
+    });
+
+    expect(
+      combat.startSkirmish([
+        { id: 'imp', name: 'Lesser Imp', hp: 12, hpMax: 12, atk: 3, initiative: 10 }
+      ])
+    ).toBe(true);
+
+    const leader = party.leader;
+    const mpBefore = leader.mp;
+
+    const castResult = combat.playerCast('fire_dart', 'imp');
+    expect(castResult.success).toBe(true);
+    expect(combat.getState().active).toBe(false);
+    expect(leader.mp).toBe(mpBefore - 6);
+    expect(inventory.count('sulfur_ash')).toBe(1);
+    expect(inventory.count('black_pearl')).toBe(1);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].victory).toBe(true);
+  });
+});

--- a/ui.js
+++ b/ui.js
@@ -29,6 +29,71 @@ export function setupUI({
   const buttonCast = document.getElementById('btnCast');
   const buttonCombat = document.getElementById('btnCombat');
   const buttonLoot = document.getElementById('btnAddLoot');
+  const sidebar = document.querySelector('.sidebar');
+  const logPanelElement = document.querySelector('.panel.log');
+
+  let combatPanel = null;
+  let combatTurnLabel = null;
+  let combatEnemyList = null;
+  let combatAttackButton = null;
+  let combatCastButton = null;
+
+  if (combat && sidebar) {
+    combatPanel = document.getElementById('combatPanel');
+    if (!combatPanel) {
+      combatPanel = document.createElement('section');
+      combatPanel.id = 'combatPanel';
+      combatPanel.className = 'panel combat';
+      combatPanel.hidden = true;
+
+      const header = document.createElement('header');
+      const title = document.createElement('h2');
+      title.textContent = 'Combat';
+      header.appendChild(title);
+
+      const statusRow = document.createElement('div');
+      statusRow.className = 'combat-status';
+      combatTurnLabel = document.createElement('span');
+      combatTurnLabel.className = 'combat-turn';
+      combatTurnLabel.textContent = 'Awaiting orders';
+      statusRow.appendChild(combatTurnLabel);
+
+      const commandRow = document.createElement('div');
+      commandRow.className = 'combat-commands';
+      combatAttackButton = document.createElement('button');
+      combatAttackButton.type = 'button';
+      combatAttackButton.className = 'combat-action combat-action-attack';
+      combatAttackButton.textContent = 'Attack';
+      combatAttackButton.disabled = true;
+      commandRow.appendChild(combatAttackButton);
+
+      combatCastButton = document.createElement('button');
+      combatCastButton.type = 'button';
+      combatCastButton.className = 'combat-action combat-action-cast';
+      combatCastButton.textContent = 'Cast Fire Dart';
+      combatCastButton.disabled = true;
+      commandRow.appendChild(combatCastButton);
+
+      combatEnemyList = document.createElement('div');
+      combatEnemyList.className = 'combat-enemies';
+
+      combatPanel.append(header, statusRow, commandRow, combatEnemyList);
+
+      if (logPanelElement && logPanelElement.parentElement === sidebar) {
+        sidebar.insertBefore(combatPanel, logPanelElement);
+      } else {
+        sidebar.appendChild(combatPanel);
+      }
+    } else {
+      combatTurnLabel = combatPanel.querySelector('.combat-turn');
+      combatEnemyList = combatPanel.querySelector('.combat-enemies');
+      combatAttackButton = combatPanel.querySelector('.combat-action-attack');
+      combatCastButton = combatPanel.querySelector('.combat-action-cast');
+    }
+  }
+
+  const canCastSpells = !!spellbook;
+  let selectedEnemyId = null;
 
   let toastTimeout = null;
   let travelBusy = false;
@@ -120,17 +185,6 @@ export function setupUI({
 
   if (buttonCast && spellbook && party) {
     buttonCast.disabled = false;
-  }
-
-  if (combat) {
-    combat.onEvent((event, payload) => {
-      if (event === 'log' && typeof payload === 'string') {
-        log(payload);
-      }
-      if (event === 'complete' && payload?.victory) {
-        showToast('Victory!');
-      }
-    });
   }
 
   function refreshParty() {
@@ -267,6 +321,133 @@ export function setupUI({
         toast.hidden = true;
       }, 250);
     }, 2200);
+  }
+
+  function renderCombatState(state = null) {
+    if (!combatPanel) return;
+    const snapshot = state ?? (typeof combat?.getState === 'function' ? combat.getState() : null);
+    const isActive = !!snapshot?.active;
+    combatPanel.hidden = !isActive;
+
+    if (!isActive) {
+      selectedEnemyId = null;
+      if (combatTurnLabel) {
+        combatTurnLabel.textContent = 'Awaiting orders';
+      }
+      if (combatEnemyList) {
+        combatEnemyList.replaceChildren();
+      }
+      if (combatAttackButton) {
+        combatAttackButton.disabled = true;
+      }
+      if (combatCastButton) {
+        combatCastButton.disabled = true;
+      }
+      return;
+    }
+
+    const enemies = Array.isArray(snapshot?.enemies) ? snapshot.enemies : [];
+    const aliveEnemies = enemies.filter((enemy) => enemy.alive);
+    if (!selectedEnemyId || !aliveEnemies.some((enemy) => enemy.id === selectedEnemyId)) {
+      selectedEnemyId = aliveEnemies[0]?.id ?? null;
+    }
+
+    if (combatTurnLabel) {
+      combatTurnLabel.textContent = snapshot.turn === 'player' ? 'Player Turn' : 'Enemy Turn';
+    }
+
+    if (combatEnemyList) {
+      combatEnemyList.replaceChildren();
+      const fragment = document.createDocumentFragment();
+      enemies.forEach((enemy) => {
+        const enemyButton = document.createElement('button');
+        enemyButton.type = 'button';
+        enemyButton.dataset.enemyId = enemy.id;
+        const classes = ['combat-enemy'];
+        if (enemy.id === selectedEnemyId) classes.push('selected');
+        if (!enemy.alive) classes.push('defeated');
+        enemyButton.className = classes.join(' ');
+        enemyButton.disabled = !enemy.alive;
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'name';
+        nameSpan.textContent = enemy.name;
+
+        const hpSpan = document.createElement('span');
+        hpSpan.className = 'hp';
+        hpSpan.textContent = enemy.alive ? `${enemy.hp}/${enemy.hpMax} HP` : 'Downed';
+
+        enemyButton.append(nameSpan, hpSpan);
+        enemyButton.addEventListener('click', () => {
+          if (!enemy.alive) return;
+          selectedEnemyId = enemy.id;
+          renderCombatState(snapshot);
+        });
+        fragment.appendChild(enemyButton);
+      });
+
+      if (!fragment.hasChildNodes()) {
+        const emptyState = document.createElement('div');
+        emptyState.className = 'combat-empty';
+        emptyState.textContent = 'No enemies remain.';
+        fragment.appendChild(emptyState);
+      }
+
+      combatEnemyList.appendChild(fragment);
+    }
+
+    const canAct = snapshot.turn === 'player';
+    const hasTarget = aliveEnemies.length > 0 && !!selectedEnemyId;
+    if (combatAttackButton) {
+      combatAttackButton.disabled = !(canAct && hasTarget);
+    }
+    if (combatCastButton) {
+      combatCastButton.disabled = !(canAct && hasTarget && canCastSpells);
+    }
+  }
+
+  if (combat && combatAttackButton) {
+    combatAttackButton.addEventListener('click', () => {
+      const result = combat.playerAttack(selectedEnemyId);
+      if (!result?.success && result?.message) {
+        showToast(result.message);
+      }
+    });
+  }
+
+  if (combat && combatCastButton) {
+    combatCastButton.addEventListener('click', () => {
+      const result = combat.playerCast('fire_dart', selectedEnemyId);
+      if (!result?.success && result?.message) {
+        showToast(result.message);
+      }
+    });
+  }
+
+  if (combat) {
+    renderCombatState(typeof combat.getState === 'function' ? combat.getState() : null);
+    combat.onEvent((event, payload) => {
+      if (event === 'log' && typeof payload === 'string') {
+        log(payload);
+        return;
+      }
+      if (event === 'state') {
+        renderCombatState(payload);
+        refreshParty();
+        refreshInventory();
+        return;
+      }
+      if (event === 'complete') {
+        renderCombatState(typeof combat.getState === 'function' ? combat.getState() : null);
+        if (payload?.victory) {
+          showToast('Victory!');
+        } else {
+          showToast('The party must regroup!');
+        }
+      }
+    });
+  } else {
+    renderCombatState();
   }
 
   setDestinations(destinations, currentDestinationId);


### PR DESCRIPTION
## Summary
- extend the combat system to manage an enemy roster, resolve player attacks/spells, and emit encounter rewards
- surface a combat command panel in the UI with target selection, action buttons, and refreshed styling
- hook combat completion into the main loop for loot/XP awards and add Vitest coverage for turn order and outcomes

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68cd466280ac8327831af60d106d6973