### PR TITLE
Add Lord British class with MP rule, palette, and party slot

### DIFF
--- a/character-models.js
+++ b/character-models.js
@@ -41,6 +41,24 @@ const CLASS_MODELS = {
     iconSecondary: '#9a7a43',
     sashColor: '#d55440'
   }),
+  [CharacterClass.LordBritish]: createModel({
+    cloakLight: '#1c3a8a',
+    cloakShadow: '#0e225c',
+    cloakTrim: '#f5d56f',
+    armorLight: '#f2e8c8',
+    armorShadow: '#c6b480',
+    accent: '#b4373f',
+    accentSecondary: '#f9ebba',
+    belt: '#4f3724',
+    medallion: '#fbe48c',
+    hair: '#c09a52',
+    icon: 'sword',
+    iconColor: '#f8d77a',
+    iconSecondary: '#8b6a2b',
+    sashColor: '#b83a48',
+    auraInner: 'rgba(255, 235, 180, 0.78)',
+    auraOuter: 'rgba(255, 205, 96, 0)'
+  }),
   [CharacterClass.Bard]: createModel({
     cloakLight: '#28504d',
     cloakShadow: '#173333',

--- a/main.js
+++ b/main.js
@@ -35,7 +35,8 @@ const party = new Party(
   [
     { name: 'Avatar', cls: CharacterClass.Avatar, STR: 12, DEX: 10, INT: 10, hpMax: 32, baseSpeed: 110 },
     { name: 'Iolo', cls: CharacterClass.Bard, STR: 9, DEX: 12, INT: 8, hpMax: 24, baseSpeed: 108 },
-    { name: 'Shamino', cls: CharacterClass.Ranger, STR: 11, DEX: 11, INT: 10, hpMax: 26, baseSpeed: 112 }
+    { name: 'Shamino', cls: CharacterClass.Ranger, STR: 11, DEX: 11, INT: 10, hpMax: 26, baseSpeed: 112 },
+    { name: 'Lord British', cls: CharacterClass.LordBritish, STR: 12, DEX: 11, INT: 14, hpMax: 38, baseSpeed: 114 }
   ],
   { followSpacing: 42, collisionRadius: 14 }
 );

--- a/party.js
+++ b/party.js
@@ -2,6 +2,7 @@ import { clamp } from './utils.js';
 
 export const CharacterClass = Object.freeze({
   Avatar: 'Avatar',
+  LordBritish: 'LordBritish',
   Fighter: 'Fighter',
   Bard: 'Bard',
   Ranger: 'Ranger',
@@ -13,6 +14,7 @@ export const CharacterClass = Object.freeze({
 
 const MP_RULES = {
   [CharacterClass.Avatar]: (INT) => INT * 2,
+  [CharacterClass.LordBritish]: (INT) => INT * 2,
   [CharacterClass.Bard]: (INT) => Math.floor(INT / 2),
   [CharacterClass.Ranger]: (INT) => Math.floor(INT / 2)
 };

--- a/tests/character.test.js
+++ b/tests/character.test.js
@@ -5,9 +5,11 @@ import { Inventory } from '../inventory.js';
 const demoItem = (overrides = {}) => ({ id: 'chain_mail', name: 'Chain Mail', weight: 6, qty: 1, equip: 'torso', ...overrides });
 
 describe('Character MP per class', () => {
-  it('Avatar gets INT*2 MP', () => {
-    const c = new Character({ name: 'A', cls: CharacterClass.Avatar, STR: 10, DEX: 10, INT: 8 });
-    expect(c.mpMax).toBe(16);
+  it('Avatar and Lord British get INT*2 MP', () => {
+    const avatar = new Character({ name: 'A', cls: CharacterClass.Avatar, STR: 10, DEX: 10, INT: 8 });
+    const lordBritish = new Character({ name: 'LB', cls: CharacterClass.LordBritish, STR: 10, DEX: 10, INT: 8 });
+    expect(avatar.mpMax).toBe(16);
+    expect(lordBritish.mpMax).toBe(16);
   });
   it('Bard/Ranger get INT/2 MP', () => {
     const bard = new Character({ name: 'B', cls: CharacterClass.Bard, STR: 10, DEX: 10, INT: 8 });


### PR DESCRIPTION
## Summary
- extend the character class enum with Lord British and mirror the Avatar MP scaling
- add a gold-and-blue character model so Lord British renders with a unique palette
- cover the new MP rule in the character vitest suite
- instantiate Lord British in the starting party so he appears in-game

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68cdd321c56083279518ee3002505b0a