### PR TITLE
Implement reagent magic and NPC conversations

### DIFF
--- a/DialogueEngine.js
+++ b/DialogueEngine.js
@@ -1,0 +1,395 @@
+import { WorldObject, registerWorldObjectType } from './WorldObject.js';
+
+const normalizeEntry = (entry) => {
+  if (!entry) {
+    return { responses: [], hints: [] };
+  }
+  if (Array.isArray(entry)) {
+    return { responses: [...entry], hints: [] };
+  }
+  if (typeof entry === 'object') {
+    const responses = Array.isArray(entry.responses)
+      ? [...entry.responses]
+      : Array.isArray(entry.lines)
+      ? [...entry.lines]
+      : typeof entry.text === 'string'
+      ? [entry.text]
+      : [];
+    const hints = Array.isArray(entry.hints) ? [...entry.hints] : [];
+    return { responses, hints };
+  }
+  if (typeof entry === 'string') {
+    return { responses: [entry], hints: [] };
+  }
+  return { responses: [], hints: [] };
+};
+
+const formatKeyword = (keyword) => keyword?.toLowerCase?.().trim() ?? '';
+
+export class NPC extends WorldObject {
+  constructor(name, x, y, npcData = {}) {
+    super(npcData.id ?? `npc_${name.toLowerCase()}`, name, 'npc', x, y, {
+      description: npcData.description ?? `You see ${name}, ${npcData.profession ?? 'a citizen of Britannia'}.`,
+      canGet: false,
+      canUse: false,
+    });
+    this.profession = npcData.profession ?? 'citizen';
+    this.schedule = npcData.schedule ?? null;
+    this.canTalk = npcData.canTalk ?? true;
+    this.dialogues = {};
+    const entries = npcData.dialogues ?? {};
+    Object.keys(entries).forEach((keyword) => {
+      this.dialogues[formatKeyword(keyword)] = normalizeEntry(entries[keyword]);
+    });
+    this.defaultResponses = Array.isArray(npcData.defaultResponses)
+      ? [...npcData.defaultResponses]
+      : ['I know little of that.'];
+  }
+
+  getResponse(keyword) {
+    const normalized = formatKeyword(keyword);
+    if (!normalized) {
+      return this.selectResponse(this.defaultResponses);
+    }
+    const entry = this.dialogues[normalized];
+    if (!entry || entry.responses.length === 0) {
+      return this.getDefaultResponse(normalized);
+    }
+    return this.selectResponse(entry.responses);
+  }
+
+  getKeywordHints(keyword) {
+    const normalized = formatKeyword(keyword);
+    const entry = this.dialogues[normalized];
+    if (!entry) return [];
+    return entry.hints ?? [];
+  }
+
+  selectResponse(responses) {
+    if (!Array.isArray(responses) || responses.length === 0) {
+      return '';
+    }
+    const index = Math.floor(Math.random() * responses.length);
+    return responses[index];
+  }
+
+  getDefaultResponse(keyword) {
+    const fallback = this.selectResponse(this.defaultResponses);
+    if (!keyword) return fallback;
+    return `${fallback} (${this.name} seems unsure about "${keyword}".)`;
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      profession: this.profession,
+      schedule: this.schedule,
+      dialogues: this.dialogues,
+      defaultResponses: [...this.defaultResponses],
+    };
+  }
+}
+
+registerWorldObjectType('npc', NPC);
+
+export class DialogueEngine {
+  constructor(gameWorld, options = {}) {
+    this.gameWorld = gameWorld;
+    this.activeNPC = null;
+    this.conversationActive = false;
+    this.historyElement = null;
+    this.inputField = null;
+    this.hintsElement = null;
+    this.titleElement = null;
+    this.container = null;
+    this.keywordHistory = [];
+    this.onKeyword = typeof options.onKeyword === 'function' ? options.onKeyword : null;
+    this.onStart = typeof options.onStart === 'function' ? options.onStart : null;
+    this.onEnd = typeof options.onEnd === 'function' ? options.onEnd : null;
+    this.createConversationUI();
+    this.installGlobalHandlers();
+  }
+
+  createConversationUI() {
+    if (typeof document === 'undefined') return;
+    this.container = createElement('div', 'conversation-overlay hidden');
+    const windowEl = createElement('div', 'conversation-window');
+
+    const header = createElement('div', 'conversation-header');
+    this.titleElement = createElement('h2', '', 'Conversation');
+    const closeButton = createElement('button', 'conversation-close', '×');
+    closeButton.type = 'button';
+    closeButton.addEventListener('click', () => this.endConversation());
+    header.append(this.titleElement, closeButton);
+
+    this.historyElement = createElement('div', 'conversation-history');
+    this.hintsElement = createElement('div', 'conversation-hints');
+
+    const inputRow = createElement('div', 'conversation-input');
+    this.inputField = document.createElement('input');
+    this.inputField.type = 'text';
+    this.inputField.placeholder = 'Type a keyword (name, job, magic...)';
+    this.inputField.autocomplete = 'off';
+    const submitButton = createElement('button', 'conversation-submit', 'Say');
+    submitButton.type = 'button';
+    submitButton.addEventListener('click', () => this.handleSubmit());
+    this.inputField.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        this.handleSubmit();
+      }
+    });
+    inputRow.append(this.inputField, submitButton);
+
+    windowEl.append(header, this.historyElement, inputRow, this.hintsElement);
+    this.container.append(windowEl);
+    document.body.appendChild(this.container);
+  }
+
+  installGlobalHandlers() {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('keydown', (event) => {
+      if (!this.conversationActive) return;
+      if (event.key === 'Escape') {
+        this.endConversation();
+      }
+    });
+  }
+
+  startConversation(npc) {
+    if (!npc || !npc.canTalk) {
+      this.gameWorld?.showMessage?.('They do not respond.');
+      return;
+    }
+    if (this.onStart) {
+      this.onStart(npc);
+    }
+    this.activeNPC = npc;
+    this.conversationActive = true;
+    this.keywordHistory = [];
+    if (this.titleElement) {
+      this.titleElement.textContent = npc.name;
+    }
+    if (this.historyElement) {
+      this.historyElement.replaceChildren();
+    }
+    if (this.hintsElement) {
+      this.hintsElement.replaceChildren();
+    }
+    if (this.container) {
+      this.container.classList.remove('hidden');
+      this.container.setAttribute('aria-hidden', 'false');
+    }
+    this.logSystem(`You greet ${npc.name}.`);
+    this.processKeyword('name');
+    this.focusInput();
+  }
+
+  focusInput() {
+    if (this.inputField) {
+      this.inputField.focus();
+      this.inputField.select?.();
+    }
+  }
+
+  handleSubmit() {
+    if (!this.conversationActive) return;
+    const value = this.inputField?.value ?? '';
+    const keyword = formatKeyword(value);
+    if (!keyword) {
+      return;
+    }
+    this.inputField.value = '';
+    this.processKeyword(keyword);
+  }
+
+  processKeyword(keyword) {
+    if (!this.activeNPC || !this.conversationActive) return;
+    const normalized = formatKeyword(keyword);
+    if (!normalized) return;
+    this.logPlayer(normalized);
+    const response = this.activeNPC.getResponse(normalized);
+    this.displayNPCResponse(response);
+    const hints = this.activeNPC.getKeywordHints(normalized);
+    this.displayKeywordHints(hints);
+    this.keywordHistory.push(normalized);
+    if (this.onKeyword) {
+      this.onKeyword(normalized, this.activeNPC);
+    }
+    if (normalized === 'bye' || normalized === 'farewell') {
+      this.logSystem(`${this.activeNPC.name} nods in parting.`);
+      this.endConversation();
+    }
+  }
+
+  displayNPCResponse(response) {
+    if (!this.historyElement) return;
+    const messages = Array.isArray(response) ? response : [response];
+    messages.filter(Boolean).forEach((text) => {
+      const line = createElement('div', 'npc-line');
+      line.textContent = text;
+      this.historyElement.appendChild(line);
+    });
+    this.historyElement.scrollTop = this.historyElement.scrollHeight;
+  }
+
+  displayKeywordHints(hints = []) {
+    if (!this.hintsElement) return;
+    this.hintsElement.replaceChildren();
+    if (!Array.isArray(hints) || hints.length === 0) {
+      return;
+    }
+    const label = createElement('div', 'hints-label', 'Keywords:');
+    this.hintsElement.appendChild(label);
+    hints.forEach((hint) => {
+      const button = createElement('button', 'hint-button', hint);
+      button.type = 'button';
+      button.addEventListener('click', () => {
+        this.inputField.value = hint;
+        this.focusInput();
+      });
+      this.hintsElement.appendChild(button);
+    });
+  }
+
+  logPlayer(keyword) {
+    if (!this.historyElement) return;
+    const entry = createElement('div', 'player-line', keyword);
+    this.historyElement.appendChild(entry);
+  }
+
+  logSystem(message) {
+    if (!this.historyElement) return;
+    const entry = createElement('div', 'system-line', message);
+    this.historyElement.appendChild(entry);
+  }
+
+  endConversation() {
+    const previousNpc = this.activeNPC;
+    this.conversationActive = false;
+    this.activeNPC = null;
+    if (this.container) {
+      this.container.classList.add('hidden');
+      this.container.setAttribute('aria-hidden', 'true');
+    }
+    if (this.onEnd) {
+      this.onEnd(previousNpc);
+    }
+  }
+}
+
+const createElement = (tag, className, textContent = '') => {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (textContent) {
+    element.textContent = textContent;
+  }
+  return element;
+};
+
+export const NPC_DATA = {
+  mariah: {
+    profession: 'healer',
+    dialogues: {
+      name: {
+        responses: ['I am Mariah, a healer of this town.'],
+        hints: ['job', 'heal', 'magic'],
+      },
+      job: {
+        responses: ['I tend to the sick and wounded. I also know something of magic.'],
+        hints: ['heal', 'magic', 'reagents'],
+      },
+      heal: {
+        responses: [
+          'I can heal thy wounds for a small donation.',
+          'Would thou like me to heal thee?',
+        ],
+        hints: ['donation'],
+      },
+      donation: {
+        responses: ['Five gold will mend even serious hurts.'],
+        hints: ['heal'],
+      },
+      magic: {
+        responses: ['Magic requires reagents to work. The eight reagents can be combined in different ways.'],
+        hints: ['reagents', 'spells'],
+      },
+      reagents: {
+        responses: ['Black Pearl, Blood Moss, Garlic, Ginseng, Mandrake Root, Nightshade, Spider Silk, and Sulfurous Ash.'],
+        hints: ['spells'],
+      },
+      spells: {
+        responses: ['The simplest healing spell requires Garlic and Ginseng. Try mixing them!'],
+        hints: ['heal', 'magic'],
+      },
+      bye: {
+        responses: ['Fare thee well, and may thy journey be safe.'],
+        hints: [],
+      },
+    },
+  },
+  gwenno: {
+    profession: 'mage shopkeeper',
+    dialogues: {
+      name: {
+        responses: ['I am Gwenno, keeper of the magic shop.'],
+        hints: ['job', 'buy'],
+      },
+      job: {
+        responses: ['I sell reagents and spell components to those who practice the mystic arts.'],
+        hints: ['reagents', 'prices', 'buy'],
+      },
+      buy: {
+        responses: ['What reagents dost thou require? I have them all, for the right price.'],
+        hints: ['reagents', 'prices'],
+      },
+      reagents: {
+        responses: ['I stock all eight reagents, though some are rarer than others.'],
+        hints: ['prices'],
+      },
+      prices: {
+        responses: ['Common reagents like Garlic are cheap. Rare ones like Mandrake Root cost much more.'],
+        hints: ['buy'],
+      },
+      spells: {
+        responses: ['I do not sell spells directly, but I know that different combinations create different effects.'],
+        hints: ['magic'],
+      },
+      magic: {
+        responses: ['Magic is dangerous without proper knowledge. Be careful what thou dost mix!'],
+        hints: ['reagents', 'buy'],
+      },
+    },
+  },
+  smithy: {
+    profession: 'blacksmith',
+    dialogues: {
+      name: {
+        responses: ['I am the town blacksmith.'],
+        hints: ['job', 'weapons'],
+      },
+      job: {
+        responses: ['I forge weapons and armor for brave adventurers.'],
+        hints: ['weapons', 'armor', 'repair'],
+      },
+      weapons: {
+        responses: ['I can craft swords, maces, and axes. What dost thou need?'],
+        hints: ['armor', 'repair'],
+      },
+      armor: {
+        responses: ['Good armor can save thy life. I recommend at least leather for starting adventurers.'],
+        hints: ['repair'],
+      },
+      repair: {
+        responses: ['Bring me thy damaged equipment and I shall restore it.'],
+        hints: ['armor'],
+      },
+      magic: {
+        responses: ['I know nothing of magic, but I hear the reagent sellers do good business.'],
+        hints: ['reagents'],
+      },
+    },
+  },
+};

--- a/GameMap.js
+++ b/GameMap.js
@@ -1,6 +1,6 @@
 import { WorldObject } from './WorldObject.js';
 
-const WALKABLE_TILES = new Set(['grass', 'cave_floor', 'cave_entrance', 'path', 'floor']);
+const WALKABLE_TILES = new Set(['grass', 'cave_floor', 'cave_entrance', 'path', 'floor', 'gate']);
 
 const createGrid = (rows) => rows.map((row) => row.split(' '));
 
@@ -18,7 +18,7 @@ const STARTER_ROOM_LAYOUT = [
   '#..A.....#',
   '#........#',
   '#........#',
-  'D....L..S#',
+  'D..G.L..S#',
   '#........#',
   '#........#',
   '#.......C#',
@@ -32,6 +32,7 @@ const STARTER_ROOM_MAP = parseAsciiMap(STARTER_ROOM_LAYOUT, {
   'L': 'floor',
   'A': 'floor',
   'C': 'floor',
+  'G': 'gate',
   'S': 'floor',
 });
 
@@ -43,7 +44,7 @@ const AREA_LIBRARY = {
     safe: true,
     spawn: { x: 2, y: 5 },
     tiles: createGrid(STARTER_ROOM_MAP),
-    transitions: [],
+    transitions: [{ tile: 'gate', to: 'forest', spawn: { x: 10, y: 10 } }],
   },
   forest: {
     id: 'forest',
@@ -62,7 +63,7 @@ const AREA_LIBRARY = {
       'tree grass path grass grass tree tree grass grass path grass grass grass tree tree grass grass tree grass tree',
       'tree grass path grass grass tree water water water water water water water tree grass grass grass tree grass tree',
       'tree grass path grass grass grass grass grass grass grass grass grass grass grass grass grass grass tree grass tree',
-      'tree grass path path path path path grass grass grass grass grass grass grass grass cave_entrance tree grass tree',
+      'tree grass gate path path path path grass grass grass grass grass grass grass grass cave_entrance tree grass tree',
       'tree grass grass grass grass grass grass grass tree tree tree grass grass grass grass grass grass tree grass tree',
       'tree grass grass grass tree tree grass grass tree tree tree grass grass tree tree grass grass grass grass tree',
       'tree grass grass grass tree tree grass grass tree grass grass grass grass tree tree grass grass grass grass tree',
@@ -75,6 +76,7 @@ const AREA_LIBRARY = {
     ]),
     transitions: [
       { tile: 'cave_entrance', to: 'cave', spawn: { x: 10, y: 17 } },
+      { tile: 'gate', to: 'starter-room', spawn: { x: 3, y: 5 } },
     ],
   },
   cave: {
@@ -120,6 +122,7 @@ const tileName = {
   path: 'Trail',
   cave_entrance: 'Cave Entrance',
   cave_floor: 'Cavern Floor',
+  gate: 'City Gate',
 };
 
 export class GameMap {

--- a/InteractionSystem.js
+++ b/InteractionSystem.js
@@ -9,7 +9,7 @@ const MODE_STATUS = {
   look: 'Looking. Click a tile or hold Shift with arrows to inspect.',
   get: 'Ready to take. Click an item or container.',
   use: 'Using. Click something to operate it.',
-  talk: 'Talk mode. Click a person to speak (coming soon).',
+  talk: 'Talk mode. Click a person to speak.',
 };
 
 export class InteractionSystem {
@@ -24,6 +24,7 @@ export class InteractionSystem {
     onInventoryChange,
     onEnemyTarget,
     getSelectedMember,
+    dialogueEngine,
   }) {
     this.canvas = canvas;
     this.map = map;
@@ -35,6 +36,7 @@ export class InteractionSystem {
     this.onInventoryChange = typeof onInventoryChange === 'function' ? onInventoryChange : null;
     this.onEnemyTarget = typeof onEnemyTarget === 'function' ? onEnemyTarget : null;
     this.getSelectedMember = typeof getSelectedMember === 'function' ? getSelectedMember : null;
+    this.dialogueEngine = dialogueEngine ?? null;
     this.mode = null;
     this._onKeyDown = (event) => this.handleKeyDown(event);
     this._onKeyUp = (event) => this.handleKeyUp(event);
@@ -271,9 +273,13 @@ export class InteractionSystem {
   }
 
   talkTo(object) {
-    if (object.type === 'npc') {
-      const line = object.dialogue?.[0] ?? `${object.name} has nothing to say yet.`;
-      this.messageDisplay?.log(line);
+    if (object?.type === 'npc') {
+      if (this.dialogueEngine && object.canTalk !== false) {
+        this.dialogueEngine.startConversation(object);
+      } else {
+        const line = object.dialogue?.[0] ?? `${object.name} has nothing to say yet.`;
+        this.messageDisplay?.log(line);
+      }
     } else {
       this.messageDisplay?.log('No one responds.');
     }

--- a/MagicShop.js
+++ b/MagicShop.js
@@ -1,0 +1,160 @@
+const createElement = (tag, className, textContent = '') => {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (textContent) {
+    element.textContent = textContent;
+  }
+  return element;
+};
+
+export class MagicShop {
+  constructor(npc, party, options = {}) {
+    this.npc = npc;
+    this.party = party;
+    this.reagentSystem = options.reagentSystem ?? null;
+    this.inventoryManager = options.inventory ?? null;
+    this.showMessage = typeof options.showMessage === 'function' ? options.showMessage : (text) => console.log(text);
+    this.onTransaction = typeof options.onTransaction === 'function' ? options.onTransaction : null;
+    this.onOpen = typeof options.onOpen === 'function' ? options.onOpen : null;
+    this.onClose = typeof options.onClose === 'function' ? options.onClose : null;
+    this.inventory = this.generateShopInventory();
+    this.container = null;
+    this.listElement = null;
+    this.goldElement = null;
+    this.titleElement = null;
+    this.createShopInterface();
+    this.installGlobalHandlers();
+  }
+
+  generateShopInventory() {
+    return {
+      garlic: { stock: 20, price: 1 },
+      ginseng: { stock: 15, price: 4 },
+      blood_moss: { stock: 12, price: 3 },
+      black_pearl: { stock: 10, price: 5 },
+      spider_silk: { stock: 8, price: 8 },
+      sulfurous_ash: { stock: 10, price: 6 },
+      nightshade: { stock: 5, price: 12 },
+      mandrake_root: { stock: 3, price: 15 },
+    };
+  }
+
+  createShopInterface() {
+    if (typeof document === 'undefined') return;
+    this.container = createElement('div', 'shop-overlay hidden');
+    const windowEl = createElement('div', 'shop-window');
+
+    const header = createElement('div', 'shop-header');
+    this.titleElement = createElement('h2', '', `${this.npc?.name ?? 'Magic Shop'}`);
+    this.goldElement = createElement('span', 'shop-gold', 'Gold: 0');
+    const closeButton = createElement('button', 'shop-close', '×');
+    closeButton.type = 'button';
+    closeButton.addEventListener('click', () => this.close());
+    header.append(this.titleElement, this.goldElement, closeButton);
+
+    this.listElement = createElement('div', 'shop-list');
+
+    windowEl.append(header, this.listElement);
+    this.container.append(windowEl);
+    document.body.appendChild(this.container);
+  }
+
+  installGlobalHandlers() {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('keydown', (event) => {
+      if (!this.isOpen()) return;
+      if (event.key === 'Escape') {
+        this.close();
+      }
+    });
+  }
+
+  isOpen() {
+    return this.container && !this.container.classList.contains('hidden');
+  }
+
+  open() {
+    if (!this.container) return;
+    if (this.onOpen) {
+      this.onOpen(this);
+    }
+    this.renderInventory();
+    this.container.classList.remove('hidden');
+    this.container.setAttribute('aria-hidden', 'false');
+  }
+
+  close() {
+    if (!this.container) return;
+    this.container.classList.add('hidden');
+    this.container.setAttribute('aria-hidden', 'true');
+    if (this.onClose) {
+      this.onClose(this);
+    }
+  }
+
+  renderInventory() {
+    if (!this.listElement) return;
+    if (this.titleElement) {
+      this.titleElement.textContent = this.npc?.name ?? 'Magic Shop';
+    }
+    this.listElement.replaceChildren();
+    Object.entries(this.inventory).forEach(([type, data]) => {
+      const row = createElement('div', 'shop-item');
+      const name = this.reagentSystem?.getReagent?.(type)?.name ?? type;
+      const stock = createElement('span', 'shop-stock', `Stock: ${data.stock}`);
+      const price = createElement('span', 'shop-price', `${data.price} gp`);
+      const nameEl = createElement('span', 'shop-name', name);
+      const controls = createElement('div', 'shop-controls');
+
+      const buyOne = createElement('button', 'shop-buy', 'Buy 1');
+      buyOne.type = 'button';
+      buyOne.disabled = data.stock <= 0;
+      buyOne.addEventListener('click', () => this.buyReagent(type, 1));
+
+      const buyFive = createElement('button', 'shop-buy', 'Buy 5');
+      buyFive.type = 'button';
+      buyFive.disabled = data.stock < 5;
+      buyFive.addEventListener('click', () => this.buyReagent(type, 5));
+
+      controls.append(buyOne, buyFive);
+      row.append(nameEl, price, stock, controls);
+      this.listElement.appendChild(row);
+    });
+    const gold = this.party?.gold ?? 0;
+    if (this.goldElement) {
+      this.goldElement.textContent = `Gold: ${gold}`;
+    }
+  }
+
+  buyReagent(reagentType, quantity = 1) {
+    const entry = this.inventory[reagentType];
+    if (!entry) return false;
+    const amount = Number.isFinite(quantity) ? Math.max(1, Math.round(quantity)) : 1;
+    if (entry.stock < amount) {
+      this.showMessage('I have not that many in stock.');
+      return false;
+    }
+    const totalCost = entry.price * amount;
+    if (!this.party || this.party.gold < totalCost) {
+      this.showMessage('Thou hast not enough gold.');
+      return false;
+    }
+    const added = this.inventoryManager?.addReagent?.(reagentType, amount, {
+      reagentSystem: this.reagentSystem,
+    });
+    if (!added) {
+      this.showMessage('Thy packs cannot hold more reagents.');
+      return false;
+    }
+    entry.stock -= amount;
+    this.party.gold -= totalCost;
+    this.showMessage(`Thou purchase${amount > 1 ? ' ' + amount : 's'} ${this.reagentSystem?.getReagent?.(reagentType)?.name ?? reagentType}.`);
+    this.renderInventory();
+    if (this.onTransaction) {
+      this.onTransaction({ type: 'buy', reagent: reagentType, quantity: amount, cost: totalCost });
+    }
+    return true;
+  }
+}

--- a/ReagentSystem.js
+++ b/ReagentSystem.js
@@ -1,0 +1,71 @@
+import { Item } from './WorldObject.js';
+
+const DEFAULT_UNIT_WEIGHT = 0.1;
+
+export class ReagentSystem {
+  constructor() {
+    this.reagents = {
+      black_pearl: { name: 'Black Pearl', rarity: 'common', value: 5 },
+      blood_moss: { name: 'Blood Moss', rarity: 'common', value: 3 },
+      garlic: { name: 'Garlic', rarity: 'abundant', value: 1 },
+      ginseng: { name: 'Ginseng', rarity: 'common', value: 4 },
+      mandrake_root: { name: 'Mandrake Root', rarity: 'rare', value: 15 },
+      nightshade: { name: 'Nightshade', rarity: 'rare', value: 12 },
+      spider_silk: { name: 'Spider Silk', rarity: 'uncommon', value: 8 },
+      sulfurous_ash: { name: 'Sulfurous Ash', rarity: 'uncommon', value: 6 },
+    };
+  }
+
+  getReagent(type) {
+    return this.reagents[type] ?? null;
+  }
+
+  listReagents() {
+    return Object.keys(this.reagents).map((key) => ({
+      type: key,
+      ...this.reagents[key],
+    }));
+  }
+
+  createReagent(type, quantity = 1, options = {}) {
+    const data = this.getReagent(type);
+    if (!data) {
+      throw new Error(`Unknown reagent type: ${type}`);
+    }
+    const amount = Number.isFinite(quantity) ? Math.max(1, Math.round(quantity)) : 1;
+    const unitWeight = Number.isFinite(options.unitWeight) ? Math.max(0, options.unitWeight) : DEFAULT_UNIT_WEIGHT;
+    const id = options.id ?? `reagent_${type}_${Date.now()}`;
+    const item = new Item(id, data.name, options.x ?? 0, options.y ?? 0, {
+      description:
+        options.description ?? `A measured portion of ${data.name.toLowerCase()} stored carefully for spellcraft.`,
+      stackable: true,
+      quantity: amount,
+      weight: unitWeight * amount,
+      canUse: true,
+      flags: { reagentType: type, rarity: data.rarity },
+    });
+    item.type = 'reagent';
+    item.reagentType = type;
+    item.unitWeight = unitWeight;
+    item.value = data.value;
+    item.rarity = data.rarity;
+    if (typeof item.onUse !== 'function') {
+      item.onUse = () => ({
+        success: true,
+        message: 'You study the reagent, imagining how it might blend with others.',
+      });
+    }
+    return item;
+  }
+}
+
+export const REAGENT_TYPES = Object.freeze([
+  'black_pearl',
+  'blood_moss',
+  'garlic',
+  'ginseng',
+  'mandrake_root',
+  'nightshade',
+  'spider_silk',
+  'sulfurous_ash',
+]);

--- a/SaveManager.js
+++ b/SaveManager.js
@@ -64,13 +64,14 @@ export class SaveManager {
   }
 }
 
-export const buildSaveData = ({ party, map, inventory, character, player, triggers }) => {
+export const buildSaveData = ({ party, map, inventory, character, player, triggers, magic }) => {
   if (party) {
     return {
       party: party?.toJSON?.() ?? null,
       world: map?.toJSON?.() ?? null,
       inventory: inventory?.toJSON?.() ?? [],
       triggers: Array.isArray(triggers) ? [...triggers] : null,
+      magic: magic ?? null,
       timestamp: Date.now(),
     };
   }
@@ -80,6 +81,7 @@ export const buildSaveData = ({ party, map, inventory, character, player, trigge
     world: map?.toJSON?.() ?? null,
     inventory: inventory?.toJSON?.() ?? [],
     inventoryGold: inventory?.gold ?? 0,
+    magic: magic ?? null,
     timestamp: Date.now(),
   };
 };

--- a/SpellMixingUI.js
+++ b/SpellMixingUI.js
@@ -1,0 +1,314 @@
+import { KNOWN_REAGENTS } from './SpellSystem.js';
+
+const createElement = (tag, className, textContent = '') => {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (textContent) {
+    element.textContent = textContent;
+  }
+  return element;
+};
+
+const reagentDisplayName = (reagentSystem, type) => reagentSystem?.getReagent(type)?.name ?? type;
+
+export class SpellMixingUI {
+  constructor(spellSystem, party, options = {}) {
+    this.spellSystem = spellSystem;
+    this.party = party;
+    this.mixingBowl = [];
+    this.isVisible = false;
+    this.getSelectedMember = typeof options.getSelectedMember === 'function'
+      ? options.getSelectedMember
+      : () => (this.party?.leader ?? null);
+    this.onOpen = typeof options.onOpen === 'function' ? options.onOpen : null;
+    this.onClose = typeof options.onClose === 'function' ? options.onClose : null;
+    this.container = null;
+    this.reagentListElement = null;
+    this.bowlElement = null;
+    this.spellNameElement = null;
+    this.castButton = null;
+    this.clearButton = null;
+    this.targetContainer = null;
+    this.currentSpell = null;
+    this.availableCounts = new Map();
+    this.createMixingInterface();
+    this.installGlobalHandlers();
+    this.refreshReagents();
+  }
+
+  createMixingInterface() {
+    if (typeof document === 'undefined') return;
+    this.container = createElement('div', 'spell-mixing-overlay hidden');
+
+    const windowEl = createElement('div', 'spell-mixing-window');
+    const header = createElement('div', 'spell-mixing-header');
+    const title = createElement('h2', '', 'Spell Mixing');
+    const closeButton = createElement('button', 'spell-mixing-close', '×');
+    closeButton.type = 'button';
+    closeButton.addEventListener('click', () => this.closeMixingInterface());
+    header.append(title, closeButton);
+
+    const content = createElement('div', 'spell-mixing-content');
+    this.reagentListElement = createElement('div', 'reagent-list');
+    this.reagentHeader = createElement('h3', '', 'Reagents');
+    this.reagentHint = createElement('p', 'reagent-hint', 'Drag reagents into the mixing bowl or click to add them.');
+    this.reagentListElement.append(this.reagentHeader, this.reagentHint);
+
+    const bowlColumn = createElement('div', 'mixing-bowl-column');
+    const bowlHeader = createElement('h3', '', 'Mixing Bowl');
+    this.bowlElement = createElement('div', 'mixing-bowl');
+    this.bowlElement.addEventListener('dragover', (event) => {
+      event.preventDefault();
+      this.bowlElement.classList.add('dragging');
+    });
+    this.bowlElement.addEventListener('dragleave', () => {
+      this.bowlElement.classList.remove('dragging');
+    });
+    this.bowlElement.addEventListener('drop', (event) => {
+      event.preventDefault();
+      this.bowlElement.classList.remove('dragging');
+      const type = event.dataTransfer?.getData('text/plain');
+      if (type) {
+        this.addReagentToBowl(type);
+      }
+    });
+
+    const bowlHint = createElement('p', 'bowl-hint', 'Arrange reagents to discover Britannia’s spells.');
+    bowlColumn.append(bowlHeader, this.bowlElement, bowlHint);
+
+    content.append(this.reagentListElement, bowlColumn);
+
+    const footer = createElement('div', 'spell-mixing-footer');
+    this.spellNameElement = createElement('div', 'spell-result', 'No spell prepared.');
+
+    this.targetContainer = createElement('div', 'spell-targets hidden');
+
+    this.castButton = createElement('button', 'spell-cast-button', 'Cast Spell');
+    this.castButton.type = 'button';
+    this.castButton.disabled = true;
+    this.castButton.addEventListener('click', () => {
+      if (!this.currentSpell) return;
+      const caster = this.getSelectedMember?.() ?? null;
+      if (!caster) {
+        this.spellSystem?.showMessage?.('No party member is ready to cast.');
+        return;
+      }
+      if (this.spellSystem.requiresTarget(this.currentSpell)) {
+        const targets = this.spellSystem.getPotentialTargets(this.currentSpell, caster);
+        if (targets.length === 0) {
+          this.spellSystem.showMessage('No valid target is available.');
+          return;
+        }
+        this.renderTargetSelection(targets, caster, this.currentSpell);
+      } else {
+        this.invokeSpell(this.currentSpell, caster, null);
+      }
+    });
+
+    this.clearButton = createElement('button', 'spell-clear-button', 'Clear Bowl');
+    this.clearButton.type = 'button';
+    this.clearButton.addEventListener('click', () => this.clearMixingBowl());
+
+    footer.append(this.spellNameElement, this.targetContainer, this.castButton, this.clearButton);
+
+    windowEl.append(header, content, footer);
+    this.container.append(windowEl);
+    document.body.appendChild(this.container);
+  }
+
+  installGlobalHandlers() {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('keydown', (event) => {
+      if (!this.isVisible) return;
+      if (event.key === 'Escape') {
+        this.closeMixingInterface();
+      }
+    });
+  }
+
+  refreshReagents() {
+    if (!this.reagentListElement) return;
+    const reagentSystem = this.spellSystem?.reagentSystem ?? null;
+    const counts = this.spellSystem?.getReagentCounts?.() ?? new Map();
+    this.availableCounts = counts;
+    const list = createElement('div', 'reagent-grid');
+    const definitions = reagentSystem?.listReagents?.() ?? KNOWN_REAGENTS.map((type) => ({ type }));
+    definitions.forEach((definition) => {
+      const type = definition.type;
+      const name = reagentDisplayName(reagentSystem, type);
+      const count = counts.get(type) ?? 0;
+      const item = createElement('div', 'reagent-item');
+      item.dataset.reagentType = type;
+      item.draggable = true;
+      item.innerHTML = `<span class="name">${name}</span><span class="count">${count}</span>`;
+      item.addEventListener('dragstart', (event) => {
+        event.dataTransfer?.setData('text/plain', type);
+      });
+      item.addEventListener('click', () => this.addReagentToBowl(type));
+      if (count <= 0) {
+        item.classList.add('unavailable');
+      }
+      list.appendChild(item);
+    });
+    this.reagentListElement.replaceChildren(this.reagentHeader, this.reagentHint, list);
+  }
+
+  refreshBowlDisplay() {
+    if (!this.bowlElement) return;
+    this.bowlElement.replaceChildren();
+    if (this.mixingBowl.length === 0) {
+      const empty = createElement('div', 'bowl-empty', 'No reagents in the bowl.');
+      this.bowlElement.appendChild(empty);
+      this.disableCastButton();
+      return;
+    }
+    this.mixingBowl.forEach((type, index) => {
+      const reagentSystem = this.spellSystem?.reagentSystem;
+      const name = reagentDisplayName(reagentSystem, type);
+      const chip = createElement('button', 'bowl-reagent', name);
+      chip.type = 'button';
+      chip.dataset.index = `${index}`;
+      chip.addEventListener('click', () => this.removeReagentFromBowl(index));
+      this.bowlElement.appendChild(chip);
+    });
+  }
+
+  addReagentToBowl(reagentType) {
+    if (!reagentType) return;
+    const available = this.availableCounts.get(reagentType) ?? 0;
+    const used = this.mixingBowl.filter((type) => type === reagentType).length;
+    if (used >= available) {
+      this.spellSystem?.showMessage?.(`You have no more ${reagentDisplayName(this.spellSystem?.reagentSystem, reagentType)}.`);
+      return;
+    }
+    this.mixingBowl.push(reagentType);
+    this.refreshBowlDisplay();
+    this.checkForValidSpell();
+  }
+
+  removeReagentFromBowl(index) {
+    if (index < 0 || index >= this.mixingBowl.length) return;
+    this.mixingBowl.splice(index, 1);
+    this.refreshBowlDisplay();
+    this.checkForValidSpell();
+  }
+
+  checkForValidSpell() {
+    const matching = this.spellSystem?.matchSpellByReagents?.(this.mixingBowl) ?? null;
+    if (!matching) {
+      this.disableCastButton();
+      this.spellNameElement.textContent = 'No spell prepared.';
+      this.currentSpell = null;
+      return;
+    }
+    const spell = this.spellSystem.getSpell(matching);
+    if (!spell) {
+      this.disableCastButton();
+      this.spellNameElement.textContent = 'No spell prepared.';
+      this.currentSpell = null;
+      return;
+    }
+    this.currentSpell = matching;
+    this.spellSystem.prepareSpell(matching);
+    this.spellNameElement.textContent = `${spell.name} (${matching.replace('_', ' ')})`;
+    this.enableCastButton();
+  }
+
+  enableCastButton() {
+    if (this.castButton) {
+      this.castButton.disabled = false;
+    }
+  }
+
+  disableCastButton() {
+    if (this.castButton) {
+      this.castButton.disabled = true;
+    }
+    if (this.targetContainer) {
+      this.targetContainer.classList.add('hidden');
+      this.targetContainer.replaceChildren();
+    }
+  }
+
+  renderTargetSelection(targets, caster, spellName) {
+    if (!this.targetContainer) return;
+    this.targetContainer.classList.remove('hidden');
+    this.targetContainer.replaceChildren();
+
+    const prompt = createElement('div', 'target-prompt', 'Choose a target:');
+    this.targetContainer.appendChild(prompt);
+
+    const options = Array.isArray(targets) ? [...targets] : [];
+
+    if (this.spellSystem.getTargetType(spellName) === 'ally' && caster) {
+      const alreadyListed = options.some((entry) => entry.entity === caster);
+      if (!alreadyListed) {
+        options.unshift({ label: `${caster.name} (self)`, entity: caster });
+      }
+    }
+
+    options.forEach((entry) => {
+      const button = createElement('button', 'target-option', entry.label);
+      button.type = 'button';
+      button.addEventListener('click', () => this.invokeSpell(spellName, caster, entry.entity));
+      this.targetContainer.appendChild(button);
+    });
+
+    const cancel = createElement('button', 'target-option cancel', 'Cancel');
+    cancel.type = 'button';
+    cancel.addEventListener('click', () => {
+      this.targetContainer.classList.add('hidden');
+      this.targetContainer.replaceChildren();
+    });
+    this.targetContainer.appendChild(cancel);
+  }
+
+  invokeSpell(spellName, caster, target) {
+    const success = this.spellSystem.castSpell(spellName, caster, target);
+    if (!success) {
+      return;
+    }
+    this.clearMixingBowl();
+    this.closeMixingInterface();
+  }
+
+  clearMixingBowl() {
+    this.mixingBowl = [];
+    this.refreshBowlDisplay();
+    this.disableCastButton();
+  }
+
+  openMixingInterface() {
+    if (!this.container) return;
+    if (this.isVisible) {
+      this.closeMixingInterface();
+      return;
+    }
+    if (this.onOpen) {
+      this.onOpen();
+    }
+    this.isVisible = true;
+    this.refreshReagents();
+    this.refreshBowlDisplay();
+    this.container.classList.remove('hidden');
+    this.container.setAttribute('aria-hidden', 'false');
+  }
+
+  closeMixingInterface() {
+    if (!this.container) return;
+    this.isVisible = false;
+    this.container.classList.add('hidden');
+    this.container.setAttribute('aria-hidden', 'true');
+    this.targetContainer?.classList.add('hidden');
+    this.targetContainer?.replaceChildren();
+    if (this.onClose) {
+      this.onClose();
+    }
+  }
+
+  isOpen() {
+    return this.isVisible;
+  }
+}

--- a/SpellSystem.js
+++ b/SpellSystem.js
@@ -1,0 +1,550 @@
+import { REAGENT_TYPES } from './ReagentSystem.js';
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const toCounts = (list = []) => {
+  const counts = new Map();
+  list.forEach((entry) => {
+    const type = entry;
+    if (!type) return;
+    const current = counts.get(type) ?? 0;
+    counts.set(type, current + 1);
+  });
+  return counts;
+};
+
+const reagentTypeOf = (item) => item?.reagentType ?? item?.flags?.reagentType ?? null;
+
+const quantityOf = (item) => (Number.isFinite(item?.quantity) ? item.quantity : 1);
+
+const distanceBetween = (a, b) => {
+  if (!a || !b) return Infinity;
+  const dx = (a.x ?? 0) - (b.x ?? 0);
+  const dy = (a.y ?? 0) - (b.y ?? 0);
+  return Math.hypot(dx, dy);
+};
+
+export class SpellSystem {
+  constructor(party, reagentSystem, options = {}) {
+    this.party = party;
+    this.reagentSystem = reagentSystem;
+    this.inventory = options.inventory ?? null;
+    this.world = options.world ?? null;
+    this.map = options.map ?? null;
+    this.combat = options.combat ?? null;
+    this.onAfterCast = typeof options.onAfterCast === 'function' ? options.onAfterCast : null;
+    this.spells = this.initializeSpells();
+    this.mixingInterface = null;
+    this.lastPreparedSpell = null;
+  }
+
+  initializeSpells() {
+    return {
+      heal: {
+        name: 'An Nox',
+        circle: 1,
+        reagents: ['garlic', 'ginseng'],
+        manaCost: 5,
+        target: 'ally',
+        effect: this.castHeal.bind(this),
+      },
+      magic_missile: {
+        name: 'Por Ylem',
+        circle: 1,
+        reagents: ['black_pearl', 'sulfurous_ash'],
+        manaCost: 4,
+        target: 'enemy',
+        effect: this.castMagicMissile.bind(this),
+      },
+      cure: {
+        name: 'An Nox Hur',
+        circle: 2,
+        reagents: ['garlic', 'ginseng', 'spider_silk'],
+        manaCost: 8,
+        target: 'ally',
+        effect: this.castCure.bind(this),
+      },
+      fireball: {
+        name: 'Por Flam',
+        circle: 2,
+        reagents: ['black_pearl', 'sulfurous_ash', 'spider_silk'],
+        manaCost: 10,
+        target: 'area',
+        effect: this.castFireball.bind(this),
+      },
+      telekinesis: {
+        name: 'Ort Por Ylem',
+        circle: 3,
+        reagents: ['blood_moss', 'spider_silk', 'mandrake_root'],
+        manaCost: 15,
+        target: 'object',
+        effect: this.castTelekinesis.bind(this),
+      },
+      unlock_magic: {
+        name: 'Ex Por',
+        circle: 3,
+        reagents: ['blood_moss', 'sulfurous_ash'],
+        manaCost: 12,
+        target: 'object',
+        effect: this.castUnlock.bind(this),
+      },
+    };
+  }
+
+  setInventory(inventory) {
+    this.inventory = inventory ?? null;
+  }
+
+  setWorld(world) {
+    this.world = world ?? null;
+  }
+
+  setCombat(combat) {
+    this.combat = combat ?? null;
+  }
+
+  setMap(map) {
+    this.map = map ?? null;
+  }
+
+  setMixingInterface(ui) {
+    this.mixingInterface = ui ?? null;
+  }
+
+  toJSON() {
+    return {
+      lastPreparedSpell: this.lastPreparedSpell ?? null,
+    };
+  }
+
+  loadFrom(data = {}) {
+    if (data && data.lastPreparedSpell && this.spells[data.lastPreparedSpell]) {
+      this.lastPreparedSpell = data.lastPreparedSpell;
+    } else {
+      this.lastPreparedSpell = null;
+    }
+  }
+
+  getSpell(spellName) {
+    return this.spells[spellName] ?? null;
+  }
+
+  prepareSpell(spellName) {
+    if (!this.spells[spellName]) return false;
+    this.lastPreparedSpell = spellName;
+    return true;
+  }
+
+  requiresTarget(spellName) {
+    const spell = this.getSpell(spellName);
+    if (!spell) return false;
+    return ['ally', 'enemy', 'area', 'object'].includes(spell.target);
+  }
+
+  getTargetType(spellName) {
+    return this.getSpell(spellName)?.target ?? 'self';
+  }
+
+  getReagentCounts() {
+    const counts = new Map();
+    const items = this.inventory?.sharedItems ?? this.party?.sharedInventory ?? [];
+    items.forEach((item) => {
+      if (!item || item.type !== 'reagent') return;
+      const type = reagentTypeOf(item);
+      if (!type) return;
+      const quantity = quantityOf(item);
+      counts.set(type, (counts.get(type) ?? 0) + quantity);
+    });
+    return counts;
+  }
+
+  hasRequiredReagents(requiredList = []) {
+    const counts = this.getReagentCounts();
+    const required = toCounts(requiredList);
+    for (const [type, amount] of required.entries()) {
+      if ((counts.get(type) ?? 0) < amount) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  consumeReagents(requiredList = []) {
+    if (!requiredList || requiredList.length === 0) return true;
+    const required = toCounts(requiredList);
+    for (const [type, amount] of required.entries()) {
+      if (this.inventory && typeof this.inventory.consumeReagent === 'function') {
+        if (!this.inventory.consumeReagent(type, amount)) {
+          return false;
+        }
+      } else if (this.party && typeof this.party.consumeReagent === 'function') {
+        if (!this.party.consumeReagent(type, amount)) {
+          return false;
+        }
+      }
+    }
+    this.mixingInterface?.refreshReagents?.();
+    return true;
+  }
+
+  matchSpellByReagents(reagentList = []) {
+    const inputCounts = toCounts(reagentList);
+    for (const [name, spell] of Object.entries(this.spells)) {
+      const spellCounts = toCounts(spell.reagents);
+      if (spellCounts.size !== inputCounts.size) continue;
+      let matches = true;
+      for (const [type, amount] of spellCounts.entries()) {
+        if (inputCounts.get(type) !== amount) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        return name;
+      }
+    }
+    return null;
+  }
+
+  canCastSpell(spellName, caster, target = null) {
+    const spell = this.getSpell(spellName);
+    if (!spell || !caster) return false;
+    if (!caster.mana || caster.mana.current < spell.manaCost) return false;
+    if (!this.hasRequiredReagents(spell.reagents)) return false;
+    if (this.requiresTarget(spellName)) {
+      const resolved = this.resolveTarget(spell, caster, target);
+      return Boolean(resolved);
+    }
+    return true;
+  }
+
+  castSpell(spellName, caster, target = null) {
+    const spell = this.getSpell(spellName);
+    if (!spell || !caster) {
+      this.showMessage('The spell fizzles before it can form.');
+      return false;
+    }
+    const resolvedTarget = this.resolveTarget(spell, caster, target);
+    if (this.requiresTarget(spellName) && !resolvedTarget) {
+      this.showMessage('No suitable target presents itself.');
+      return false;
+    }
+    if (!this.canCastSpell(spellName, caster, resolvedTarget)) {
+      this.showMessage('The spell fails. Perhaps more power or reagents are needed.');
+      return false;
+    }
+    if (!this.consumeReagents(spell.reagents)) {
+      this.showMessage('You lack the necessary reagents.');
+      return false;
+    }
+    caster.mana.current = clamp((caster.mana?.current ?? 0) - spell.manaCost, 0, caster.mana?.max ?? spell.manaCost);
+    spell.effect(caster, resolvedTarget);
+    this.prepareSpell(spellName);
+    if (this.combat?.onUpdate) {
+      this.combat.onUpdate({ party: this.party, enemies: this.combat.enemies });
+    }
+    if (this.onAfterCast) {
+      this.onAfterCast({ spell: spellName, caster, target: resolvedTarget });
+    }
+    return true;
+  }
+
+  castPreparedSpell(caster, target = null) {
+    if (!this.lastPreparedSpell) {
+      this.showMessage('No spell is currently prepared. Mix reagents first.');
+      return false;
+    }
+    return this.castSpell(this.lastPreparedSpell, caster, target);
+  }
+
+  resolveTarget(spell, caster, providedTarget) {
+    if (!spell) return null;
+    const targetType = spell.target ?? 'self';
+    if (targetType === 'self') {
+      return caster;
+    }
+    if (providedTarget) {
+      return providedTarget;
+    }
+    if (targetType === 'ally') {
+      const allies = this.getAllies();
+      if (!allies || allies.length === 0) return caster;
+      const wounded = allies
+        .filter((ally) => ally.health && ally.health.current < ally.health.max)
+        .sort((a, b) => a.health.current / a.health.max - b.health.current / b.health.max);
+      return wounded[0] ?? caster;
+    }
+    if (targetType === 'enemy' || targetType === 'area') {
+      if (caster?.target && caster.target.alive) {
+        return caster.target;
+      }
+      const enemies = this.getEnemies();
+      return enemies.find((enemy) => enemy.alive) ?? null;
+    }
+    if (targetType === 'object') {
+      const objects = this.getNearbyObjects(caster, () => true, 6);
+      return objects[0] ?? null;
+    }
+    return providedTarget ?? null;
+  }
+
+  getAllies() {
+    return this.party?.members?.filter((member) => member?.alive) ?? [];
+  }
+
+  getEnemies() {
+    if (this.combat?.enemies) {
+      return this.combat.enemies;
+    }
+    if (this.map?.getObjects) {
+      return this.map.getObjects().filter((object) => object?.type === 'enemy');
+    }
+    return [];
+  }
+
+  getPotentialTargets(spellName, caster) {
+    const spell = this.getSpell(spellName);
+    if (!spell) return [];
+    const targetType = spell.target ?? 'self';
+    if (targetType === 'ally') {
+      return this.getAllies().map((ally) => ({ label: ally.name, entity: ally }));
+    }
+    if (targetType === 'enemy' || targetType === 'area') {
+      return this.getEnemies()
+        .filter((enemy) => enemy.alive)
+        .map((enemy) => ({ label: enemy.name, entity: enemy }));
+    }
+    if (targetType === 'object') {
+      return this.getNearbyObjects(caster, (object) => this.isValidObjectTarget(object, spellName), 8).map((object) => ({
+        label: object.name,
+        entity: object,
+      }));
+    }
+    return [];
+  }
+
+  getNearbyObjects(origin, predicate, radius = 6) {
+    if (!this.map?.getObjects) return [];
+    const objects = this.map.getObjects();
+    const results = [];
+    objects.forEach((object) => {
+      if (object?.type === 'enemy' || object?.type === 'npc') return;
+      if (typeof predicate === 'function' && !predicate(object)) return;
+      if (distanceBetween(origin, object) <= radius) {
+        results.push(object);
+      }
+    });
+    return results;
+  }
+
+  isValidObjectTarget(object, spellName) {
+    if (!object) return false;
+    if (spellName === 'unlock_magic') {
+      if (object.type === 'door') {
+        return Boolean(object.locked);
+      }
+      if (object.type === 'container') {
+        return Boolean(object.locked);
+      }
+      return false;
+    }
+    if (spellName === 'telekinesis') {
+      return ['item', 'container', 'door'].includes(object.type) && !object.fixed;
+    }
+    return true;
+  }
+
+  getEnemiesInArea(x, y, radius = 1) {
+    const enemies = this.getEnemies();
+    return enemies.filter((enemy) => enemy.alive && Math.abs((enemy.x ?? 0) - x) <= radius + 0.5 && Math.abs((enemy.y ?? 0) - y) <= radius + 0.5);
+  }
+
+  showMessage(text) {
+    if (!text) return;
+    if (this.world?.showMessage) {
+      this.world.showMessage(text);
+    } else {
+      console.log(text);
+    }
+  }
+
+  showFloatingDamage(x, y, amount) {
+    if (!Number.isFinite(amount) || amount <= 0) return;
+    if (this.world?.showFloatingDamage) {
+      this.world.showFloatingDamage(x ?? 0, y ?? 0, amount);
+    }
+  }
+
+  showExplosionEffect(x, y) {
+    this.showMessage('A burst of flame erupts!');
+    if (this.world?.showFloatingDamage) {
+      this.world.showFloatingDamage(x ?? 0, y ?? 0, '✴');
+    }
+  }
+
+  findAdjacentTile(caster) {
+    if (!caster || !this.map) return null;
+    const baseX = Math.floor(caster.x ?? 0);
+    const baseY = Math.floor(caster.y ?? 0);
+    const offsets = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 0, y: -1 },
+      { x: 1, y: 1 },
+      { x: -1, y: 1 },
+      { x: 1, y: -1 },
+      { x: -1, y: -1 },
+    ];
+    for (const offset of offsets) {
+      const tx = baseX + offset.x;
+      const ty = baseY + offset.y;
+      if (this.isTileFree(tx, ty)) {
+        return { x: tx + 0.5, y: ty + 0.5 };
+      }
+    }
+    return null;
+  }
+
+  isTileFree(tileX, tileY) {
+    if (!this.map) return false;
+    if (!this.map.isWalkableTile?.(this.map.tileAt(tileX, tileY))) {
+      return false;
+    }
+    const blockers = this.map.objectsAt?.(tileX, tileY) ?? [];
+    return !blockers.some((object) => typeof object.blocksMovement === 'function' && object.blocksMovement());
+  }
+
+  castHeal(caster, target) {
+    const recipient = target ?? caster;
+    if (!recipient?.health) {
+      this.showMessage('The spell finds no flesh to mend.');
+      return;
+    }
+    const healAmount = 10 + Math.floor((caster?.int ?? 0) / 3);
+    const before = recipient.health.current;
+    recipient.health.current = clamp(recipient.health.current + healAmount, 0, recipient.health.max);
+    const restored = recipient.health.current - before;
+    this.showMessage(`${recipient.name} is healed for ${restored} points!`);
+  }
+
+  castMagicMissile(caster, target) {
+    if (!target || !target.health) {
+      this.showMessage('Select a target for Magic Missile!');
+      return;
+    }
+    const damage = Math.max(1, 3 + Math.floor((caster?.int ?? 0) / 4));
+    const dealt = target.takeDamage ? target.takeDamage(damage) : Math.min(damage, target.health.current);
+    if (!target.takeDamage) {
+      target.health.current = Math.max(0, target.health.current - damage);
+    }
+    this.showFloatingDamage(target.x, target.y, dealt);
+    this.showMessage(`Magic Missile hits ${target.name} for ${dealt} damage!`);
+  }
+
+  castCure(caster, target) {
+    const recipient = target ?? caster;
+    if (!recipient) {
+      this.showMessage('There is no one to cure.');
+      return;
+    }
+    let cleansed = false;
+    if (Array.isArray(recipient.conditions)) {
+      const before = recipient.conditions.length;
+      recipient.conditions = recipient.conditions.filter((condition) => condition !== 'poisoned' && condition !== 'diseased');
+      cleansed = recipient.conditions.length < before;
+    } else if (recipient.status === 'poisoned') {
+      recipient.status = 'active';
+      cleansed = true;
+    }
+    const relief = 4 + Math.floor((caster?.int ?? 0) / 5);
+    if (recipient.health) {
+      recipient.health.current = clamp(recipient.health.current + relief, 0, recipient.health.max);
+    }
+    this.showMessage(`${recipient.name} is cleansed${cleansed ? ' of ailment' : ''}!`);
+  }
+
+  castFireball(caster, target) {
+    let targetX;
+    let targetY;
+    if (target && Number.isFinite(target.x) && Number.isFinite(target.y)) {
+      targetX = target.x;
+      targetY = target.y;
+    } else if (target?.entity && Number.isFinite(target.entity.x)) {
+      targetX = target.entity.x;
+      targetY = target.entity.y;
+    } else {
+      targetX = caster?.target?.x ?? caster?.x ?? 0;
+      targetY = caster?.target?.y ?? caster?.y ?? 0;
+    }
+    const damage = 8 + Math.floor((caster?.int ?? 0) / 2);
+    const enemies = this.getEnemiesInArea(targetX, targetY, 1);
+    enemies.forEach((enemy) => {
+      const dealt = enemy.takeDamage ? enemy.takeDamage(damage) : Math.min(damage, enemy.health.current);
+      if (!enemy.takeDamage) {
+        enemy.health.current = Math.max(0, enemy.health.current - damage);
+      }
+      this.showFloatingDamage(enemy.x, enemy.y, dealt);
+    });
+    this.showExplosionEffect(targetX, targetY);
+    this.showMessage(`Fireball explodes for ${damage} damage!`);
+  }
+
+  castTelekinesis(caster, target) {
+    if (!target) {
+      this.showMessage('The spell grasps at nothing.');
+      return;
+    }
+    if (target.fixed) {
+      this.showMessage('The object refuses to budge.');
+      return;
+    }
+    if (distanceBetween(caster, target) > 6) {
+      this.showMessage('The object is too distant to move.');
+      return;
+    }
+    const destination = this.findAdjacentTile(caster);
+    if (!destination) {
+      this.showMessage('No room nearby to guide the object.');
+      return;
+    }
+    if (typeof target.setPosition === 'function') {
+      target.setPosition(destination.x, destination.y);
+    } else {
+      target.x = destination.x;
+      target.y = destination.y;
+    }
+    this.showMessage(`Invisible forces lift ${target.name} to ${caster.name}'s side!`);
+  }
+
+  castUnlock(caster, target) {
+    if (!target) {
+      this.showMessage('There is nothing to unlock.');
+      return;
+    }
+    if (target.type === 'door') {
+      if (!target.locked) {
+        this.showMessage('The door is already free to open.');
+        return;
+      }
+      target.locked = false;
+      if (typeof target.setOpen === 'function') {
+        target.setOpen(true);
+      }
+      this.showMessage('A shimmer surrounds the door as its lock clicks open!');
+      return;
+    }
+    if (target.type === 'container') {
+      if (!target.locked) {
+        this.showMessage('The container is not locked.');
+        return;
+      }
+      target.locked = false;
+      this.showMessage('Mystic energy releases the container latch.');
+      return;
+    }
+    this.showMessage('The magic finds no lock to unbind.');
+  }
+}
+
+export const KNOWN_REAGENTS = Object.freeze(REAGENT_TYPES);

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
           <button id="saveButton" type="button">Save</button>
           <button id="loadButton" type="button">Load</button>
         </div>
-        <p class="controls-hint">WASD / Arrows move &bull; L/G/U/T actions &bull; 1-8 select &bull; F: Formation &bull; SPACE: Pause &bull; I: Toggle inventory</p>
+        <p class="controls-hint">WASD / Arrows move &bull; L/G/U/T actions &bull; M: Mix spell &bull; C: Cast prepared spell &bull; 1-8 select &bull; F: Formation &bull; SPACE: Pause &bull; I: Toggle inventory</p>
       </section>
       <section class="party-panel">
         <header><h2>Party</h2></header>

--- a/party.js
+++ b/party.js
@@ -38,6 +38,8 @@ export class Party {
       : [];
     this.movementController = null;
     this.leaderIndex = 0;
+    this.gold = Number.isFinite(options.gold) ? Math.max(0, Math.round(options.gold)) : 50;
+    this.inventoryRef = null;
     if (Number.isFinite(options.leaderIndex)) {
       this.setLeader(options.leaderIndex);
     } else if (this.members.length > 0) {
@@ -55,6 +57,10 @@ export class Party {
 
   setMovementController(controller) {
     this.movementController = controller ?? null;
+  }
+
+  setInventoryRef(inventory) {
+    this.inventoryRef = inventory ?? null;
   }
 
   addMember(entry) {
@@ -112,6 +118,36 @@ export class Party {
     return this.formation;
   }
 
+  addGold(amount = 0) {
+    const value = Number.isFinite(amount) ? Math.round(amount) : 0;
+    if (value <= 0) return this.gold;
+    this.gold += value;
+    return this.gold;
+  }
+
+  spendGold(amount = 0) {
+    const cost = Number.isFinite(amount) ? Math.round(amount) : 0;
+    if (cost <= 0) return true;
+    if (this.gold < cost) return false;
+    this.gold -= cost;
+    return true;
+  }
+
+  addReagent(type, quantity = 1, options = {}) {
+    if (!this.inventoryRef || typeof this.inventoryRef.addReagent !== 'function') return false;
+    return this.inventoryRef.addReagent(type, quantity, options);
+  }
+
+  getReagentCount(type) {
+    if (!this.inventoryRef || typeof this.inventoryRef.getReagentCount !== 'function') return 0;
+    return this.inventoryRef.getReagentCount(type);
+  }
+
+  consumeReagent(type, quantity = 1) {
+    if (!this.inventoryRef || typeof this.inventoryRef.consumeReagent !== 'function') return false;
+    return this.inventoryRef.consumeReagent(type, quantity);
+  }
+
   moveParty(direction, dt = 0.016, gameWorld = null) {
     if (this.movementController && typeof this.movementController.moveParty === 'function') {
       this.movementController.moveParty(direction, dt, gameWorld);
@@ -164,6 +200,7 @@ export class Party {
       leaderIndex: this.leaderIndex,
       formation: this.formation,
       sharedInventory: this.sharedInventory.map((item) => (item?.toJSON ? item.toJSON() : item)),
+      gold: this.gold,
     };
   }
 
@@ -175,6 +212,7 @@ export class Party {
       leaderIndex: data.leaderIndex,
       formation: data.formation,
       sharedInventory: data.sharedInventory,
+      gold: data.gold,
     });
   }
 }

--- a/style.css
+++ b/style.css
@@ -329,3 +329,283 @@ canvas[data-mode='use'] {
 canvas[data-mode='talk'] {
   box-shadow: inset 0 0 0 2px rgba(204, 170, 255, 0.38);
 }
+
+.spell-mixing-overlay,
+.conversation-overlay,
+.shop-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(4, 8, 16, 0.72);
+  backdrop-filter: blur(6px);
+  z-index: 200;
+}
+
+.spell-mixing-overlay.hidden,
+.conversation-overlay.hidden,
+.shop-overlay.hidden {
+  display: none;
+}
+
+.spell-mixing-window,
+.conversation-window,
+.shop-window {
+  background: rgba(10, 20, 34, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(132, 182, 255, 0.18);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  padding: 20px 24px;
+  max-width: 680px;
+  width: min(90vw, 720px);
+  color: #f4f8ff;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.spell-mixing-header,
+.conversation-header,
+.shop-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.spell-mixing-header h2,
+.conversation-header h2,
+.shop-header h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0.04em;
+}
+
+.spell-mixing-close,
+.conversation-close,
+.shop-close {
+  background: rgba(30, 56, 92, 0.6);
+  border: 1px solid rgba(140, 188, 255, 0.32);
+  border-radius: 12px;
+  color: #dceaff;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 6px 10px;
+}
+
+.spell-mixing-content {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.reagent-list h3,
+.mixing-bowl-column h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+}
+
+.reagent-hint,
+.bowl-hint {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: #9dbbef;
+}
+
+.reagent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.reagent-item {
+  background: rgba(16, 30, 52, 0.9);
+  border-radius: 12px;
+  border: 1px solid rgba(118, 168, 255, 0.25);
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: grab;
+  font-size: 13px;
+  transition: border-color 0.2s ease;
+}
+
+.reagent-item.unavailable {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.reagent-item:hover {
+  border-color: rgba(168, 210, 255, 0.5);
+}
+
+.mixing-bowl {
+  min-height: 160px;
+  border: 1px dashed rgba(150, 200, 255, 0.35);
+  border-radius: 16px;
+  padding: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-content: flex-start;
+  background: rgba(12, 24, 40, 0.6);
+}
+
+.mixing-bowl.dragging {
+  border-color: rgba(188, 232, 255, 0.65);
+  background: rgba(20, 34, 52, 0.8);
+}
+
+.bowl-empty {
+  margin: auto;
+  color: #8fa9d6;
+  font-size: 13px;
+}
+
+.bowl-reagent {
+  background: rgba(42, 78, 122, 0.85);
+  border: 1px solid rgba(158, 204, 255, 0.4);
+  color: #e3f0ff;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.spell-mixing-footer {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.spell-result {
+  font-size: 15px;
+  font-weight: 600;
+  color: #dfe9ff;
+}
+
+.spell-targets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.spell-targets.hidden {
+  display: none;
+}
+
+.target-option {
+  background: rgba(26, 46, 74, 0.8);
+  border: 1px solid rgba(120, 174, 255, 0.35);
+  border-radius: 10px;
+  color: #d8e7ff;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.target-option.cancel {
+  background: rgba(92, 36, 36, 0.7);
+  border-color: rgba(232, 98, 98, 0.45);
+}
+
+.spell-cast-button,
+.spell-clear-button,
+.conversation-submit,
+.hint-button,
+.shop-buy {
+  background: linear-gradient(135deg, rgba(46, 82, 140, 0.85), rgba(24, 46, 88, 0.85));
+  border: 1px solid rgba(140, 190, 255, 0.35);
+  border-radius: 12px;
+  color: #e7f2ff;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.spell-cast-button:disabled,
+.spell-clear-button:disabled,
+.shop-buy:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.conversation-history {
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-right: 6px;
+}
+
+.player-line {
+  align-self: flex-end;
+  color: #a0d0ff;
+}
+
+.npc-line {
+  color: #f2f7ff;
+}
+
+.system-line {
+  font-style: italic;
+  color: #93addd;
+}
+
+.conversation-input {
+  display: flex;
+  gap: 10px;
+}
+
+.conversation-input input {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(120, 170, 255, 0.3);
+  background: rgba(12, 22, 38, 0.6);
+  color: #f4f8ff;
+}
+
+.conversation-hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hints-label {
+  width: 100%;
+  font-size: 12px;
+  color: #8fb4f0;
+}
+
+.shop-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shop-item {
+  display: grid;
+  grid-template-columns: 1.3fr 0.6fr 0.6fr 1fr;
+  gap: 10px;
+  align-items: center;
+  background: rgba(14, 26, 44, 0.65);
+  border-radius: 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(108, 160, 240, 0.25);
+}
+
+.shop-controls {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.shop-gold {
+  font-size: 14px;
+  color: #d6e6ff;
+}


### PR DESCRIPTION
## Summary
- add reagent catalog and spellcasting engine with combat effects and save support
- introduce spell mixing overlay, keyword-driven dialogue, and reagent shop NPCs in the town map
- extend party inventory for reagent stacking and hook new systems into input handling and overlays

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68ce163a194c8327b27d0c5a23010b5d