### PR TITLE
Alias placeholder character sheet for player animations

### DIFF
--- a/PlaceholderGraphics.js
+++ b/PlaceholderGraphics.js
@@ -55,6 +55,11 @@ export class PlaceholderGraphics {
     });
 
     this.canvases.set('characters', canvas);
+    // Animation definitions sometimes reference a dedicated 'player' sheet.
+    // Alias the generated character atlas so those lookups resolve cleanly.
+    if (!this.canvases.has('player')) {
+      this.canvases.set('player', canvas);
+    }
   }
 
   createMonsterSheet() {


### PR DESCRIPTION
## Summary
- alias the generated placeholder character atlas to the `player` sheet name
- ensure animation configurations that reference `player` sprites resolve during placeholder rendering

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68ce4809b89c8327b645ae5db57db90c