### PR TITLE
Fix service worker fetch handling

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,2 +1,46 @@
-// Service worker intentionally disabled to avoid caching errors during placeholder graphics development.
-// This stub keeps registration hooks alive for future use without intercepting fetch requests.
+// Network-only service worker used to keep registration hooks alive while placeholder graphics load.
+// Ensures fetch handlers always resolve with a valid Response to avoid TypeError: Failed to convert value to 'Response'.
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    (async () => {
+      try {
+        const preloaded = await event.preloadResponse;
+        if (preloaded) {
+          return preloaded;
+        }
+      } catch (error) {
+        console.debug('[service-worker] preloadResponse failed', error);
+      }
+
+      try {
+        return await fetch(event.request);
+      } catch (error) {
+        console.warn('[service-worker] Network request failed; returning offline response.', error);
+        if (event.request.mode === 'navigate') {
+          return new Response(
+            '<!doctype html><title>Offline</title><body><h1>Offline</h1><p>The game is currently unavailable offline.</p></body>',
+            {
+              status: 503,
+              statusText: 'Service Unavailable',
+              headers: { 'Content-Type': 'text/html; charset=utf-8' },
+            },
+          );
+        }
+        return new Response('', { status: 503, statusText: 'Service Unavailable' });
+      }
+    })(),
+  );
+});


### PR DESCRIPTION
## Summary
- replace the stub service worker with a network-only handler that keeps registration hooks active
- ensure fetch events always resolve to a valid Response and add a simple offline fallback for navigations

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68ce649b008c832782b395d5bf65d846