### PR TITLE
Align lighting updates with renderer

### DIFF
--- a/GameLoop.js
+++ b/GameLoop.js
@@ -26,13 +26,15 @@ export class GameLoop {
       this.game.animationSystem?.updateAnimations(deltaSeconds);
       this.game.effectsRenderer?.updateEffects(deltaSeconds);
       this.game.particleSystem?.update(deltaSeconds);
-      this.game.lightingSystem?.updateLighting();
+
       this.game.worldRenderer?.render();
       this.game.effectsRenderer?.render();
       const ctx = this.game.spriteRenderer?.ctx;
       if (ctx) {
         this.game.particleSystem?.render(ctx);
       }
+
+      this.game.lightingSystem?.updateLighting();
       this.game.lightingSystem?.applyLighting();
       this.game.ui?.render();
       this.lastTime = currentTime;


### PR DESCRIPTION
## Summary
- render the world frame before recalculating the lighting mask so the mask uses the latest camera transform

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68ce7c66c7b48327a249a964831319ea