### PR TITLE
Fix world object rehydration and add coverage

### DIFF
--- a/DialogueEngine.js
+++ b/DialogueEngine.js
@@ -88,6 +88,59 @@ export class NPC extends WorldObject {
       defaultResponses: [...this.defaultResponses],
     };
   }
+
+  static fromJSON(data = {}) {
+    if (!data || typeof data !== 'object') {
+      throw new TypeError('Invalid NPC data.');
+    }
+
+    const cloneValue = (value) => {
+      if (Array.isArray(value)) {
+        return value.map((entry) => cloneValue(entry));
+      }
+      if (value && typeof value === 'object') {
+        return Object.fromEntries(
+          Object.entries(value).map(([key, entry]) => [key, cloneValue(entry)])
+        );
+      }
+      return value;
+    };
+
+    const npc = new NPC(data.name ?? data.id ?? 'NPC', data.x ?? 0, data.y ?? 0, {
+      id: data.id,
+      description: data.description,
+      profession: data.profession,
+      schedule: cloneValue(data.schedule),
+      canTalk: data.canTalk,
+      dialogues: cloneValue(data.dialogues ?? {}),
+      defaultResponses: Array.isArray(data.defaultResponses)
+        ? [...data.defaultResponses]
+        : cloneValue(data.defaultResponses),
+    });
+
+    npc.type = data.type ?? npc.type;
+    npc.flags = cloneValue(data.flags ?? {});
+    npc.contains = Array.isArray(data.contains)
+      ? data.contains.map((entry) =>
+          entry instanceof WorldObject ? entry : WorldObject.fromJSON(entry)
+        )
+      : [];
+
+    if (Number.isFinite(data.weight)) {
+      npc.weight = Number(data.weight);
+    }
+    if (typeof data.canGet === 'boolean') {
+      npc.canGet = data.canGet;
+    }
+    if (typeof data.canUse === 'boolean') {
+      npc.canUse = data.canUse;
+    }
+    if (typeof data.isOpen === 'boolean') {
+      npc.isOpen = data.isOpen;
+    }
+
+    return npc;
+  }
 }
 
 registerWorldObjectType('npc', NPC);

--- a/tests/save.test.js
+++ b/tests/save.test.js
@@ -5,6 +5,9 @@ import { Player } from '../Player.js';
 import { GameMap } from '../GameMap.js';
 import { Inventory } from '../inventory.js';
 import { ItemGenerator } from '../ItemGenerator.js';
+import { WorldObject } from '../WorldObject.js';
+import { ReagentSystem } from '../ReagentSystem.js';
+import { NPC } from '../DialogueEngine.js';
 
 describe('SaveManager', () => {
   it('stores and retrieves serialized game data', () => {
@@ -39,6 +42,83 @@ describe('ItemGenerator', () => {
     expect(loot.length).toBeGreaterThan(0);
     const item = loot[0];
     expect(['weapon', 'armor', 'consumable']).toContain(item.type);
+  });
+});
+
+describe('WorldObject.fromJSON', () => {
+  it('rehydrates reagent stacks with metadata intact', () => {
+    const reagents = new ReagentSystem();
+    const reagent = reagents.createReagent('ginseng', 3, { x: 5, y: 7 });
+    reagent.flags = { ...reagent.flags, infused: true };
+    const serialized = reagent.toJSON();
+
+    const roundTrip = WorldObject.fromJSON(serialized);
+    expect(roundTrip).not.toBe(reagent);
+    expect(roundTrip).toBeInstanceOf(WorldObject);
+    expect(roundTrip.type).toBe('reagent');
+    expect(roundTrip.x).toBe(5);
+    expect(roundTrip.y).toBe(7);
+    expect(roundTrip.quantity).toBe(3);
+    expect(roundTrip.stackable).toBe(true);
+    expect(roundTrip.flags.reagentType).toBe('ginseng');
+    expect(roundTrip.flags.infused).toBe(true);
+
+    const stashJSON = {
+      id: 'stash_1',
+      name: 'Secret Stash',
+      type: 'stash',
+      x: 1,
+      y: 2,
+      contains: [serialized],
+    };
+
+    const stash = WorldObject.fromJSON(stashJSON);
+    expect(stash.type).toBe('stash');
+    expect(Array.isArray(stash.contains)).toBe(true);
+    expect(stash.contains).toHaveLength(1);
+    const nested = stash.contains[0];
+    expect(nested).toBeInstanceOf(WorldObject);
+    expect(nested.type).toBe('reagent');
+    expect(nested.quantity).toBe(3);
+    expect(nested.flags.reagentType).toBe('ginseng');
+  });
+
+  it('rehydrates NPCs through class-specific factories', () => {
+    const npc = new NPC('Iolo', 12, 6, {
+      id: 'npc_iolo',
+      profession: 'bard',
+      schedule: { morning: 'tavern' },
+      canTalk: true,
+      dialogues: {
+        job: {
+          responses: ['I sing tales of valor.'],
+          hints: ['ask about music'],
+        },
+      },
+      defaultResponses: ['Perhaps another time.'],
+    });
+    npc.flags = { alignment: 'friendly' };
+    npc.weight = 0;
+    npc.canGet = true;
+    npc.canUse = true;
+
+    const serialized = npc.toJSON();
+    const restored = WorldObject.fromJSON(serialized);
+
+    expect(restored).toBeInstanceOf(NPC);
+    expect(restored.id).toBe('npc_iolo');
+    expect(restored.name).toBe('Iolo');
+    expect(restored.x).toBe(12);
+    expect(restored.y).toBe(6);
+    expect(restored.profession).toBe('bard');
+    expect(restored.schedule).toEqual({ morning: 'tavern' });
+    expect(restored.defaultResponses).toEqual(['Perhaps another time.']);
+    expect(restored.dialogues.job.responses).toEqual(['I sing tales of valor.']);
+    expect(restored.dialogues.job.hints).toEqual(['ask about music']);
+    expect(restored.flags.alignment).toBe('friendly');
+    expect(restored.weight).toBe(0);
+    expect(restored.canGet).toBe(true);
+    expect(restored.canUse).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- update `WorldObject.fromJSON` to delegate to class-level factories and preserve metadata for unregistered types
- add `NPC.fromJSON` to rebuild dialogue NPCs while restoring core flags and state
- cover reagent stacks and NPCs with new deserialization regression tests

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68ce8bcdf7f8832794139fb3cdd722de