### PR TITLE
Normalize input key handling for movement

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -1,11 +1,44 @@
-const KEY_BINDINGS = {
-  left: ['ArrowLeft', 'a', 'A'],
-  right: ['ArrowRight', 'd', 'D'],
-  up: ['ArrowUp', 'w', 'W'],
-  down: ['ArrowDown', 's', 'S']
+const KEYBOARD_EVENTS = ['keydown', 'keyup'];
+
+const KEY_MAP = new Map([
+  ['ArrowUp', 'arrowup'],
+  ['Up', 'arrowup'],
+  ['arrowup', 'arrowup'],
+  ['up', 'arrowup'],
+  ['ArrowDown', 'arrowdown'],
+  ['Down', 'arrowdown'],
+  ['arrowdown', 'arrowdown'],
+  ['down', 'arrowdown'],
+  ['ArrowLeft', 'arrowleft'],
+  ['Left', 'arrowleft'],
+  ['arrowleft', 'arrowleft'],
+  ['left', 'arrowleft'],
+  ['ArrowRight', 'arrowright'],
+  ['Right', 'arrowright'],
+  ['arrowright', 'arrowright'],
+  ['right', 'arrowright'],
+  [' ', 'space'],
+  ['Spacebar', 'space'],
+  ['Space', 'space'],
+  ['space', 'space'],
+]);
+
+const normalizeKey = (key) => {
+  if (typeof key !== 'string') return '';
+  const direct = KEY_MAP.get(key);
+  if (direct) return direct;
+  const lower = key.toLowerCase();
+  return KEY_MAP.get(lower) ?? lower;
 };
 
-const KEYBOARD_EVENTS = ['keydown', 'keyup'];
+const PREVENT_DEFAULT_KEYS = new Set(['arrowup', 'arrowdown', 'arrowleft', 'arrowright', 'space']);
+
+const KEY_BINDINGS = {
+  left: ['arrowleft', 'a'],
+  right: ['arrowright', 'd'],
+  up: ['arrowup', 'w'],
+  down: ['arrowdown', 's'],
+};
 
 export class InputController {
   constructor(target = window) {
@@ -18,13 +51,15 @@ export class InputController {
   _install() {
     KEYBOARD_EVENTS.forEach((type) => {
       const handler = (event) => {
+        const normalized = normalizeKey(event.key);
+        if (!normalized) return;
         if (event.type === 'keydown') {
-          this.keys.add(event.key);
-          if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(event.key)) {
+          this.keys.add(normalized);
+          if (PREVENT_DEFAULT_KEYS.has(normalized) && typeof event.preventDefault === 'function') {
             event.preventDefault();
           }
         } else if (event.type === 'keyup') {
-          this.keys.delete(event.key);
+          this.keys.delete(normalized);
         }
       };
       this._handlers.set(type, handler);
@@ -44,7 +79,7 @@ export class InputController {
   }
 
   isKeyDown(key) {
-    return this.keys.has(key);
+    return this.keys.has(normalizeKey(key));
   }
 
   getDirection() {
@@ -65,6 +100,6 @@ export class InputController {
   }
 
   _anyDown(keys) {
-    return keys.some((key) => this.keys.has(key));
+    return keys.some((key) => this.keys.has(normalizeKey(key)));
   }
 }

--- a/tests/controls.test.js
+++ b/tests/controls.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InputController } from '../controls.js';
+
+describe('InputController', () => {
+  const createMockTarget = () => {
+    const listeners = new Map();
+    return {
+      addEventListener: (type, handler) => {
+        listeners.set(type, handler);
+      },
+      removeEventListener: (type) => {
+        listeners.delete(type);
+      },
+      listeners,
+    };
+  };
+
+  it('recognises Down key aliases as downward movement', () => {
+    const target = createMockTarget();
+    const input = new InputController(target);
+    const keydown = target.listeners.get('keydown');
+    const keyup = target.listeners.get('keyup');
+    expect(typeof keydown).toBe('function');
+    expect(typeof keyup).toBe('function');
+
+    const preventDefault = vi.fn();
+    keydown?.({ type: 'keydown', key: 'Down', preventDefault });
+
+    const direction = input.getDirection();
+    expect(direction).toEqual({ x: 0, y: 1 });
+    expect(preventDefault).toHaveBeenCalled();
+
+    keyup?.({ type: 'keyup', key: 'Down', preventDefault });
+    expect(input.getDirection()).toEqual({ x: 0, y: 0 });
+
+    input.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize movement key handling so Down/Up/Left/Right aliases map to the same internal values
- avoid case sensitivity by storing lower-case bindings and reusing the normalized keys for preventDefault checks
- add a unit test covering the Down key alias to confirm downward movement works

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68cea38645d4832785bd566620287bee